### PR TITLE
Fix access to HTTPS endpoint such as Github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo 
 
 
 FROM alpine:3.7
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/eclipse/che-plugin-broker/che-plugin-broker /usr/local/bin
 ENTRYPOINT ["che-plugin-broker"]


### PR DESCRIPTION
Some certificates are missing in the docker image. 
Because of that https access to Github fails.
This PR adds certificates on each build to fix this issue.
AFAIK certificates might expire, so the issue might appear if the broker doesn't get updates for some period of time. I'm not sure how long and how to fix it properly. 