### PR TITLE
Add memory-limit field to sidecar definition

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -86,6 +86,7 @@ type Container struct {
 	EditorCommands []EditorCommand `json:"editor-commands" yaml:"editor-commands"`
 	Volumes        []Volume        `json:"volumes" yaml:"volumes"`
 	Ports          []ExposedPort   `json:"ports" yaml:"ports"`
+	MemoryLimit    string          `json:"memory-limit" yaml:"memory-limit"`
 }
 
 type Editor struct {


### PR DESCRIPTION
Field name: `memory-limit`. It is supposed that it accepts values supported by K8s 