### PR TITLE
Renamed STARTING event to STARTED and added publishing of STARTED event

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -35,11 +35,12 @@ var (
 
 // Start executes plugins metas processing and sends data to Che master
 func Start(metas []model.PluginMeta) {
-	if ok, status := storage.SetStatus(model.StatusStarting); !ok {
+	if ok, status := storage.SetStatus(model.StatusStarted); !ok {
 		m := fmt.Sprintf("Starting broker in state '%s' is not allowed", status)
 		pubFailed(m)
 		log.Fatal(m)
 	}
+	pubStarted()
 
 	for _, meta := range metas {
 		err := processPlugin(meta)
@@ -80,6 +81,13 @@ func closeConsumers() {
 }
 
 func (tb *tunnelBroadcaster) Close() { tb.tunnel.Close() }
+
+func pubStarted() {
+	bus.Pub(&model.StartedEvent{
+		Status:      model.StatusStarted,
+		WorkspaceID: cfg.WorkspaceID,
+	})
+}
 
 func pubFailed(err string) {
 	bus.Pub(&model.ErrorEvent{

--- a/model/model.go
+++ b/model/model.go
@@ -18,7 +18,7 @@ type BrokerStatus string
 const (
 	StatusIdle BrokerStatus = "IDLE"
 
-	StatusStarting BrokerStatus = "STARTING"
+	StatusStarted BrokerStatus = "STARTED"
 
 	StatusDone BrokerStatus = "DONE"
 
@@ -109,6 +109,14 @@ type CheDependency struct {
 type CheDependencies struct {
 	Plugins []CheDependency `json:"plugins" yaml:"plugins"`
 }
+
+type StartedEvent struct {
+	Status      BrokerStatus `json:"status" yaml:"status"`
+	WorkspaceID string       `json:"workspaceId" yaml:"workspaceId"`
+}
+
+// Type returns BrokerStatusEventType.
+func (e *StartedEvent) Type() string { return BrokerStatusEventType }
 
 type ErrorEvent struct {
 	Status      BrokerStatus `json:"status" yaml:"status"`

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -42,9 +42,9 @@ func SetStatus(status model.BrokerStatus) (ok bool, currentValue model.BrokerSta
 	s.Lock()
 	defer s.Unlock()
 	switch {
-	case s.status == model.StatusIdle && status == model.StatusStarting:
+	case s.status == model.StatusIdle && status == model.StatusStarted:
 		fallthrough
-	case s.status == model.StatusStarting && status == model.StatusDone:
+	case s.status == model.StatusStarted && status == model.StatusDone:
 		s.status = status
 		return true, status
 	default:


### PR DESCRIPTION
Renamed STARTING event to STARTED: it is needed since the event on Che Server is renamed in this way.
Added publishing of STARTED event: it is needed to notify Che Server if Plugin Broker process is started or not.