### PR TITLE
Revert "Renamed STARTING event to STARTED and added publishing of STARTED event"

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -35,12 +35,11 @@ var (
 
 // Start executes plugins metas processing and sends data to Che master
 func Start(metas []model.PluginMeta) {
-	if ok, status := storage.SetStatus(model.StatusStarted); !ok {
+	if ok, status := storage.SetStatus(model.StatusStarting); !ok {
 		m := fmt.Sprintf("Starting broker in state '%s' is not allowed", status)
 		pubFailed(m)
 		log.Fatal(m)
 	}
-	pubStarted()
 
 	// Clear any existing plugins from dir
 	log.Println("Cleaning /plugins dir")
@@ -88,13 +87,6 @@ func closeConsumers() {
 }
 
 func (tb *tunnelBroadcaster) Close() { tb.tunnel.Close() }
-
-func pubStarted() {
-	bus.Pub(&model.StartedEvent{
-		Status:      model.StatusStarted,
-		WorkspaceID: cfg.WorkspaceID,
-	})
-}
 
 func pubFailed(err string) {
 	bus.Pub(&model.ErrorEvent{

--- a/model/model.go
+++ b/model/model.go
@@ -18,7 +18,7 @@ type BrokerStatus string
 const (
 	StatusIdle BrokerStatus = "IDLE"
 
-	StatusStarted BrokerStatus = "STARTED"
+	StatusStarting BrokerStatus = "STARTING"
 
 	StatusDone BrokerStatus = "DONE"
 
@@ -111,14 +111,6 @@ type CheDependency struct {
 type CheDependencies struct {
 	Plugins []CheDependency `json:"plugins" yaml:"plugins"`
 }
-
-type StartedEvent struct {
-	Status      BrokerStatus `json:"status" yaml:"status"`
-	WorkspaceID string       `json:"workspaceId" yaml:"workspaceId"`
-}
-
-// Type returns BrokerStatusEventType.
-func (e *StartedEvent) Type() string { return BrokerStatusEventType }
 
 type ErrorEvent struct {
 	Status      BrokerStatus `json:"status" yaml:"status"`

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -42,9 +42,9 @@ func SetStatus(status model.BrokerStatus) (ok bool, currentValue model.BrokerSta
 	s.Lock()
 	defer s.Unlock()
 	switch {
-	case s.status == model.StatusIdle && status == model.StatusStarted:
+	case s.status == model.StatusIdle && status == model.StatusStarting:
 		fallthrough
-	case s.status == model.StatusStarted && status == model.StatusDone:
+	case s.status == model.StatusStarting && status == model.StatusDone:
 		s.status = status
 		return true, status
 	default:


### PR DESCRIPTION
Reverts eclipse/che-plugin-broker#9
PR that respects changes from #9 is not merged in Che master https://github.com/eclipse/che/pull/11344 and merging of #9 broke Che 7 flow.
And even if we merged it right now it would not help since yesterday's nightly doesn't have it.