### PR TITLE
Allow broker parse any attributes of Endpoint

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -47,17 +47,11 @@ type PluginMeta struct {
 	URL string `json:"url" yaml:"url"`
 }
 
-type EndpointAttributes struct {
-	Protocol string `json:"protocol" yaml:"protocol"`
-	Path     string `json:"path" yaml:"path"`
-	Type     string `json:"type" yaml:"type"`
-}
-
 type Endpoint struct {
 	Name       string             `json:"name" yaml:"name"`
 	Public     bool               `json:"public" yaml:"public"`
 	TargetPort int                `json:"targetPort" yaml:"targetPort"`
-	Attributes EndpointAttributes `json:"attributes" yaml:"attributes"`
+	Attributes map[string]string  `json:"attributes" yaml:"attributes"`
 }
 
 type EnvVar struct {


### PR DESCRIPTION
ServerConfig in Che has a lot of optional attributes. And Plugin Endpoint can use the same attributes. 
But Broker parses only a couple of known attributes for the time being. This unsync with Che Server config doesn't allow to leverage all Che features for sidecars.
This PR removes attributes names in favor of plain string vocabulary matching when attribute name doesn't influence whether the attribute will be parsed. 