### PR TITLE
Added publishing info and error logs to Che Server WebSocket endpoint

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -91,24 +91,24 @@ func (tb *tunnelBroadcaster) Close() { tb.tunnel.Close() }
 
 func pubStarted() {
 	bus.Pub(&model.StartedEvent{
-		Status:      model.StatusStarted,
-		WorkspaceID: cfg.WorkspaceID,
+		Status:    model.StatusStarted,
+		RuntimeID: cfg.RuntimeID,
 	})
 }
 
 func pubFailed(err string) {
 	bus.Pub(&model.ErrorEvent{
-		Status:      model.StatusFailed,
-		Error:       err,
-		WorkspaceID: cfg.WorkspaceID,
+		Status:    model.StatusFailed,
+		Error:     err,
+		RuntimeID: cfg.RuntimeID,
 	})
 }
 
 func pubDone(tooling string) {
 	bus.Pub(&model.SuccessEvent{
-		Status:      model.StatusDone,
-		WorkspaceID: cfg.WorkspaceID,
-		Tooling:     tooling,
+		Status:    model.StatusDone,
+		RuntimeID: cfg.RuntimeID,
+		Tooling:   tooling,
 	})
 }
 

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -37,8 +37,9 @@ var (
 	// Token to access wsmaster API
 	Token string
 
-	// WorkspaceID the id of workspace runtime this broker belongs to.
-	WorkspaceID string
+	// RuntimeID the id of workspace runtime this machine belongs to.
+	RuntimeID    model.RuntimeID
+	runtimeIDRaw string
 )
 
 func init() {
@@ -73,10 +74,10 @@ func init() {
 			"By default the value from 'CHE_AUTH_ENABLED' environment variable is used or `false` if it is missing",
 	)
 	flag.StringVar(
-		&WorkspaceID,
-		"workspace-id",
+		&runtimeIDRaw,
+		"runtime-id",
 		"",
-		"The identifier of the workspace",
+		"The identifier of the runtime in format 'workspace:environment:ownerId'",
 	)
 }
 
@@ -97,10 +98,15 @@ func Parse() {
 		Token = os.Getenv("CHE_MACHINE_TOKEN")
 	}
 
-	// workspace-id
-	if len(WorkspaceID) == 0 {
-		log.Fatal("Workspace ID required(set it with -workspace-id argument)")
+	// runtime-id
+	if len(runtimeIDRaw) == 0 {
+		log.Fatal("Runtime ID required(set it with -runtime-id argument)")
 	}
+	parts := strings.Split(runtimeIDRaw, ":")
+	if len(parts) != 3 {
+		log.Fatalf("Expected runtime id to be in format 'workspace:env:ownerId'")
+	}
+	RuntimeID = model.RuntimeID{Workspace: parts[0], Environment: parts[1], OwnerId: parts[2]}
 }
 
 // Print prints configuration.
@@ -108,7 +114,11 @@ func Print() {
 	log.Print("Broker configuration")
 	log.Printf("  Push endpoint: %s", PushStatusesEndpoint)
 	log.Printf("  Auth enabled: %t", AuthEnabled)
-	log.Printf("  Workspace: %s", WorkspaceID)
+	log.Print("  Runtime ID:")
+	log.Printf("    Workspace: %s", RuntimeID.Workspace)
+	log.Printf("    Environment: %s", RuntimeID.Environment)
+	log.Printf("    OwnerId: %s", RuntimeID.OwnerId)
+
 }
 
 // ReadConfig reads content of file by path cfg.FilePath,

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	cfg.Print()
 
 	statusTun := connectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
-	broker.PushStatuses(statusTun)
+	broker.PushEvents(statusTun)
 
 	metas := cfg.ReadConfig()
 	broker.Start(metas)

--- a/model/model.go
+++ b/model/model.go
@@ -12,7 +12,17 @@
 
 package model
 
+import "time"
+
 type BrokerStatus string
+
+const (
+	// StderrStream value of InstallerLogEvent.Stream if log line is from process STDERR.
+	StderrStream = "STDERR"
+
+	// StdoutStream value of InstallerLogEvent.Stream if log line is from process STDOUT.
+	StdoutStream = "STDOUT"
+)
 
 // Broker statuses
 const (
@@ -27,6 +37,8 @@ const (
 	BrokerStatusEventType = "broker/statusChanged"
 
 	BrokerResultEventType = "broker/result"
+
+	BrokerLogEventType = "broker/log"
 )
 
 // RuntimeID is an identifier of running workspace.
@@ -145,3 +157,19 @@ type SuccessEvent struct {
 
 // Type returns BrokerResultEventType.
 func (e *SuccessEvent) Type() string { return BrokerResultEventType }
+
+type PluginBrokerLogEvent struct {
+	RuntimeID RuntimeID `json:"runtimeId" yaml:"runtimeId"`
+
+	// Time when this event occurred.
+	Time time.Time `json:"time" yaml:"text"`
+
+	// Text is written by plugin broker line of text.
+	Text string `json:"text" yaml:"text"`
+
+	// Stream defines whether it is STDERR or STDOUT
+	Stream string `json:"stream" yaml:"stream"`
+}
+
+// Type returns BrokerLogEventType.
+func (e *PluginBrokerLogEvent) Type() string { return BrokerLogEventType }

--- a/model/model.go
+++ b/model/model.go
@@ -29,6 +29,19 @@ const (
 	BrokerResultEventType = "broker/result"
 )
 
+// RuntimeID is an identifier of running workspace.
+// Included to the plugin broker log events.
+type RuntimeID struct {
+	// Workspace is an identifier of the workspace e.g. "workspace123456".
+	Workspace string `json:"workspaceId" yaml:"workspaceId"`
+
+	// Environment is a name of environment e.g. "default".
+	Environment string `json:"envName" yaml:"envName"`
+
+	// OwnerId is an identifier of user who is runtime owner.
+	OwnerId string `json:"ownerId" yaml:"ownerId"`
+}
+
 type PluginMeta struct {
 	ID string `json:"id" yaml:"id"`
 
@@ -48,10 +61,10 @@ type PluginMeta struct {
 }
 
 type Endpoint struct {
-	Name       string             `json:"name" yaml:"name"`
-	Public     bool               `json:"public" yaml:"public"`
-	TargetPort int                `json:"targetPort" yaml:"targetPort"`
-	Attributes map[string]string  `json:"attributes" yaml:"attributes"`
+	Name       string            `json:"name" yaml:"name"`
+	Public     bool              `json:"public" yaml:"public"`
+	TargetPort int               `json:"targetPort" yaml:"targetPort"`
+	Attributes map[string]string `json:"attributes" yaml:"attributes"`
 }
 
 type EnvVar struct {
@@ -107,17 +120,17 @@ type CheDependencies struct {
 }
 
 type StartedEvent struct {
-	Status      BrokerStatus `json:"status" yaml:"status"`
-	WorkspaceID string       `json:"workspaceId" yaml:"workspaceId"`
+	Status    BrokerStatus `json:"status" yaml:"status"`
+	RuntimeID RuntimeID    `json:"runtimeId" yaml:"runtimeId"`
 }
 
 // Type returns BrokerStatusEventType.
 func (e *StartedEvent) Type() string { return BrokerStatusEventType }
 
 type ErrorEvent struct {
-	Status      BrokerStatus `json:"status" yaml:"status"`
-	WorkspaceID string       `json:"workspaceId" yaml:"workspaceId"`
-	Error       string       `json:"error" yaml:"error"`
+	Status    BrokerStatus `json:"status" yaml:"status"`
+	RuntimeID RuntimeID    `json:"runtimeId" yaml:"runtimeId"`
+	Error     string       `json:"error" yaml:"error"`
 }
 
 // Type returns BrokerStatusEventType.
@@ -125,9 +138,9 @@ func (e *ErrorEvent) Type() string { return BrokerStatusEventType }
 
 // SuccessEvent is used to send encoded workspace tooling configuration to Che master
 type SuccessEvent struct {
-	Status      BrokerStatus `json:"status" yaml:"status"`
-	WorkspaceID string       `json:"workspaceId" yaml:"workspaceId"`
-	Tooling     string       `json:"tooling" yaml:"tooling"`
+	Status    BrokerStatus `json:"status" yaml:"status"`
+	RuntimeID RuntimeID    `json:"runtimeId" yaml:"runtimeId"`
+	Tooling   string       `json:"tooling" yaml:"tooling"`
 }
 
 // Type returns BrokerResultEventType.


### PR DESCRIPTION
### What does this PR do?
Added publishing info and error logs to Che Server WebSocket endpoint.

In this PR there is detailed Broker logs output that is written in STDOUT and may be fetched on OpenShift console for debug purposes, and summary logs output that is published to clients.
<details>
<summary>Plugin Broker Pod Logs</summary>

```
2018/10/01 09:02:31 Broker configuration
2018/10/01 09:02:31   Push endpoint: ws://che-eclipse-che.172.19.20.145.nip.io/api/websocket
2018/10/01 09:02:31   Auth enabled: false
2018/10/01 09:02:31   Runtime ID:
2018/10/01 09:02:31     Workspace: workspacee9rue7fxrxa251f9
2018/10/01 09:02:31     Environment: default
2018/10/01 09:02:31     OwnerId: che
2018/10/01 09:02:31 Cleaning /plugins dir
2018/10/01 09:02:31 Started Plugin Broker
2018/10/01 09:02:31 List of plugins and editors to install
2018/10/01 09:02:31 - che-dummy-plugin:0.0.1 - A hello world theia plug-in wrapped into a Che Plug-in
2018/10/01 09:02:31 - che-service-plugin:0.0.1 - Che Plug-in with Theia plug-in and container definition providing a service
2018/10/01 09:02:31 - org.eclipse.che.editor.theia:1.0.0 - Eclipse Theia
2018/10/01 09:02:31 Starting plugins processing
2018/10/01 09:02:31 Stared processing plugin 'che-dummy-plugin:0.0.1'
2018/10/01 09:02:31 Downloading archive 'https://github.com/ws-skeleton/che-dummy-plugin/releases/download/untagged-8f3e198285a2f3b6b2db/che-dummy-plugin.tar.gz'  for plugin 'che-dummy-plugin:0.0.1' to '/tmp/che-plugin-broker285687574/testArchive.tar.gz'
2018/10/01 09:02:32 Untarring archive 'https://github.com/ws-skeleton/che-dummy-plugin/releases/download/untagged-8f3e198285a2f3b6b2db/che-dummy-plugin.tar.gz'  for plugin 'che-dummy-plugin:0.0.1' to '/tmp/che-plugin-broker285687574/testArchive.tar.gz'
2018/10/01 09:02:32 Resolving Che plugins for 'che-dummy-plugin:0.0.1'
2018/10/01 09:02:32 Copying dependencies for 'che-dummy-plugin:0.0.1'
2018/10/01 09:02:32 Copying file '/tmp/che-plugin-broker285687574/testArchive/hello_world_plugin.theia' to '/plugins/hello_world_plugin.theia'
2018/10/01 09:02:32 Stared processing plugin 'che-service-plugin:0.0.1'
2018/10/01 09:02:32 Downloading archive 'https://github.com/ws-skeleton/che-service-plugin/releases/download/untagged-5c4c888ff2de8ae7a5e2/che-service-plugin.tar.gz'  for plugin 'che-service-plugin:0.0.1' to '/tmp/che-plugin-broker847505277/testArchive.tar.gz'
2018/10/01 09:02:39 Untarring archive 'https://github.com/ws-skeleton/che-service-plugin/releases/download/untagged-5c4c888ff2de8ae7a5e2/che-service-plugin.tar.gz'  for plugin 'che-service-plugin:0.0.1' to '/tmp/che-plugin-broker847505277/testArchive.tar.gz'
2018/10/01 09:02:39 Resolving Che plugins for 'che-service-plugin:0.0.1'
2018/10/01 09:02:39 Copying dependencies for 'che-service-plugin:0.0.1'
2018/10/01 09:02:39 Copying file '/tmp/che-plugin-broker847505277/testArchive/che_ui_service_plugin.theia' to '/plugins/che_ui_service_plugin.theia'
2018/10/01 09:02:39 Stared processing plugin 'org.eclipse.che.editor.theia:1.0.0'
2018/10/01 09:02:39 Downloading archive 'https://github.com/ws-skeleton/che-editor-theia/releases/download/untagged-fe2d4dc402d14923b78c/che-editor-plugin.tar.gz'  for plugin 'org.eclipse.che.editor.theia:1.0.0' to '/tmp/che-plugin-broker676330168/testArchive.tar.gz'
2018/10/01 09:02:39 Untarring archive 'https://github.com/ws-skeleton/che-editor-theia/releases/download/untagged-fe2d4dc402d14923b78c/che-editor-plugin.tar.gz'  for plugin 'org.eclipse.che.editor.theia:1.0.0' to '/tmp/che-plugin-broker676330168/testArchive.tar.gz'
2018/10/01 09:02:39 Resolving Che plugins for 'org.eclipse.che.editor.theia:1.0.0'
2018/10/01 09:02:39 Copying dependencies for 'org.eclipse.che.editor.theia:1.0.0'
2018/10/01 09:02:39 All plugins have been successfully processed
```
</details>

<details>
<summary>Plugin Broker Logs Displayed on Client</summary>

Client will receive events with the following text
```
Started Plugin Broker
List of plugins and editors to install
- che-service-plugin:0.0.1 - Che Plug-in with Theia plug-in and container definition providing a service
- che-dummy-plugin:0.0.1 - A hello world theia plug-in wrapped into a Che Plug-in
- org.eclipse.che.editor.theia:1.0.0 - Eclipse Theia
Starting plugins processing
All plugins have been successfully processed
MountVolume.SetUp succeeded for volume "che-workspace-token-g2vrr" 
Container image "eclipse/che-dev:nightly" already present on machine
Created container
Started container
pulling image "wsskeleton/che-hello"
```
</details>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11069