### PR TITLE
Propagate id and version to Che Server

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -170,7 +170,7 @@ func processPlugin(meta model.PluginMeta) error {
 	}
 
 	printDebug("Resolving Che plugins for '%s:%s'", meta.ID, meta.Version)
-	err = resolveToolingConfig(pluginPath)
+	err = resolveToolingConfig(&meta, pluginPath)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func processPlugin(meta model.PluginMeta) error {
 	return copyDependencies(pluginPath)
 }
 
-func resolveToolingConfig(workDir string) error {
+func resolveToolingConfig(meta *model.PluginMeta, workDir string) error {
 	toolingConfPath := filepath.Join(workDir, "che-plugin.yaml")
 	f, err := ioutil.ReadFile(toolingConfPath)
 	if err != nil {
@@ -191,7 +191,7 @@ func resolveToolingConfig(workDir string) error {
 		return err
 	}
 
-	return storage.AddTooling(tooling)
+	return storage.AddTooling(meta, tooling)
 }
 
 func copyDependencies(workDir string) error {

--- a/model/model.go
+++ b/model/model.go
@@ -112,6 +112,18 @@ type ToolingConf struct {
 	Editors    []Editor    `json:"editors" yaml:"editors"`
 }
 
+type ChePlugin struct {
+	ID      string `json:"id" yaml:"id"`
+	Version string `json:"version" yaml:"version"`
+	//Name should not be propagated until Che Server requires it to have the following format "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+	//while it is not respected by all of plugin
+	//See https://github.com/eclipse/che/blob/251e5e261bac2bf4c93f113e52fd18d26b5989ab/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingValidator.java#L27
+	//Name       string      `json:"name" yaml:"name"`
+	Endpoints  []Endpoint  `json:"endpoints" yaml:"endpoints"`
+	Containers []Container `json:"containers" yaml:"containers"`
+	Editors    []Editor    `json:"editors" yaml:"editors"`
+}
+
 type CheDependency struct {
 	ID       string `json:"id" yaml:"id"`
 	Version  string `json:"version" yaml:"version"`

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -27,7 +27,7 @@ type Storage struct {
 	sync.RWMutex
 	status  model.BrokerStatus
 	err     string
-	tooling []model.ToolingConf
+	plugins []model.ChePlugin
 }
 
 // Status returns current status of broker execution
@@ -66,18 +66,25 @@ func SetErr(err string) {
 	s.err = err
 }
 
-// Tooling returns configuration of Che plugins tooling resolved during the broker execution.
+// Tooling returns configuration of Che Plugins resolved during the broker execution.
 // At any particular point of time configuration might be incomplete if tooling resolution failed or not completed yet
-func Tooling() (*[]model.ToolingConf, error) {
+func Tooling() (*[]model.ChePlugin, error) {
 	s.Lock()
 	defer s.Unlock()
-	return &s.tooling, nil
+	return &s.plugins, nil
 }
 
 // AddTooling adds configuration of model.ToolingConf to the results of broker execution
-func AddTooling(tooling *model.ToolingConf) error {
+func AddTooling(meta *model.PluginMeta, tooling *model.ToolingConf) error {
 	s.Lock()
 	defer s.Unlock()
-	s.tooling = append(s.tooling, *tooling)
+	plugin := &model.ChePlugin{
+		ID:         meta.ID,
+		Version:    meta.Version,
+		Containers: tooling.Containers,
+		Editors:    tooling.Editors,
+		Endpoints:  tooling.Endpoints,
+	}
+	s.plugins = append(s.plugins, *plugin)
 	return nil
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,103 @@
+//
+// Copyright (c) 2012-2018 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package storage
+
+import (
+	"github.com/eclipse/che-plugin-broker/model"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSettingStatusOfStorage(t *testing.T) {
+	tables := []struct {
+		initialStatus model.BrokerStatus
+		newStatus     model.BrokerStatus
+		isChanged     bool
+	}{
+		{model.StatusIdle, model.StatusStarted, true},
+		{model.StatusIdle, model.StatusDone, false},
+		{model.StatusIdle, model.StatusFailed, false},
+		{model.StatusIdle, model.StatusIdle, false},
+		{model.StatusStarted, model.StatusDone, true},
+		{model.StatusStarted, model.StatusIdle, false},
+		{model.StatusStarted, model.StatusFailed, false},
+		{model.StatusStarted, model.StatusStarted, false},
+		{model.StatusDone, model.StatusIdle, false},
+		{model.StatusDone, model.StatusDone, false},
+		{model.StatusDone, model.StatusStarted, false},
+		{model.StatusDone, model.StatusDone, false},
+	}
+
+	for _, table := range tables {
+		//storage1 := &Storage{status:table.initialStatus}
+		s.status = table.initialStatus
+		ok, currentValue := SetStatus(table.newStatus)
+
+		if ok != table.isChanged {
+			t.Errorf("Status expected not to be changed from %s to %s but it was", table.initialStatus, table.newStatus)
+		}
+
+		if table.initialStatus != table.newStatus && !ok && currentValue != table.initialStatus {
+			t.Errorf("Current state is changed from %s to %s but it shouldn't be", table.initialStatus, currentValue)
+		}
+	}
+}
+
+func TestAddingTollingToStorage(t *testing.T) {
+	meta := model.PluginMeta{
+		ID:      "org.plugin.id",
+		Version: "1.0.0",
+		Name:    "test-plugin",
+	}
+	conf := model.ToolingConf{
+		Containers: []model.Container{{Name: "container"}},
+		Editors:    []model.Editor{{ID: "editor-id"}},
+		Endpoints:  []model.Endpoint{{Name: "endpoint"}},
+	}
+
+	AddTooling(&meta, &conf)
+
+	actualNumber := len(s.plugins)
+	if actualNumber != 1 {
+		t.Errorf("Storage has %v elements after adding one plugin", actualNumber)
+	}
+
+	plugin := s.plugins[0]
+
+	assert.Equal(t, meta.ID, plugin.ID, "Plugin ID is not expected")
+	assert.Equal(t, meta.Version, plugin.Version, "Plugin Version is not expected")
+
+	assert.ElementsMatch(t, conf.Containers, plugin.Containers, "Plugin Containers are not expected")
+	assert.ElementsMatch(t, conf.Endpoints, plugin.Endpoints, "Plugin Endpoints are not expected")
+	assert.ElementsMatch(t, conf.Editors, plugin.Editors, "Plugin Editors are not expected")
+}
+
+func TestGettingTollingFromStorage(t *testing.T) {
+	s.plugins = []model.ChePlugin{
+		{
+			ID:         "org.plugin.id",
+			Version:    "1.0.0",
+			Containers: []model.Container{{Name: "container"}},
+			Editors:    []model.Editor{{ID: "editor-id"}},
+			Endpoints:  []model.Endpoint{{Name: "endpoint"}},
+		},
+	}
+
+	chePlugins, e := Tooling()
+
+	if e != nil {
+		t.Errorf("Error occurs during toolling receiving: %s", e)
+	}
+
+	assert.ElementsMatch(t, s.plugins, *chePlugins, "Plugins list is not expected")
+}


### PR DESCRIPTION
### What does this PR do?
Adds propagating of id and version field to Che Server.
Che Server [parses](https://github.com/eclipse/che/blob/1e78fa4d6e14f5dd0265d61cc70b26efe740d257/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerService.java#L108
) objects published by Plugin Broker as [Che Plugins](https://github.com/eclipse/che/blob/851c3a8be75b4cee278af1b98bd08c9fbb044976/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginBase.java#L21-L23) which has id, version and name field. But previosly Plugin Broker didn't publish id, version and name fields and Che Server doesn't have an ability to match received configuration with Che Plugin. It may be needed like for resolving Che Plugin Commands, or containers names evaluation.

This PR doesn't add propagation of Che Plugin name because Che 7 workspace won't work since names of some of plugins doesn't suite [name format](https://github.com/eclipse/che/blob/251e5e261bac2bf4c93f113e52fd18d26b5989ab/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingValidator.java#L27) which Che Server requires. Example of such plugin https://github.com/eclipse/che-plugin-registry/blob/master/plugins/che-machine-exec-plugin/0.0.1/meta.yaml#L4
So, propagation of plugin name should be uncommented when https://github.com/eclipse/che/issues/11479 will be fixed.

### What issues does this PR fix or reference?
It is related to https://github.com/eclipse/che/issues/9546