### PR TITLE
Allow running brokers locally, add debug info

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 */init/cmd/init-plugin-broker
 */vscode/cmd/vscode-extension-broker
 */cmd/cmd
+main
+*/cmd/config.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ theia-plugin-broker
 init-plugin-broker
 vscode-extension-broker
 **/cmd/cmd
+main
 
 *.o
 *.a

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o i
 CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o vscode-extension-broker brokers/vscode/cmd/main.go
 ```
 
+### Run checks
+
 - run tests:
 
 ```shell
@@ -99,6 +101,19 @@ golangci-lint run -v
 ```shell
 docker build -f build/CI/Dockerfile .
 ```
+
+### Check brokers locally
+
+Prerequisites:
+
+    - Folder /plugins exists on the host and writable for the user
+
+- Go to a broker cmd directory, e.g. `brokers/vscode/cmd`
+- Compile binaries `go build main.go`
+- Run binary `./main -disable-push -runtime-id wsId:env:ownerId`
+- Check JSON with sidecar configuration in the very bottom of the output
+- Check that needed files are in `/plugins`
+- To cleanup `/plugins` folder **init** broker can be used
 
 ### Dependencies
 

--- a/brokers/che-plugin-broker/broker.go
+++ b/brokers/che-plugin-broker/broker.go
@@ -96,7 +96,9 @@ func (cheBroker *ChePluginBroker) Start(metas []model.PluginMeta) {
 	}
 
 	cheBroker.PrintInfo("All plugins have been successfully processed")
-	cheBroker.PubDone(string(pluginsBytes))
+	result := string(pluginsBytes)
+	cheBroker.PrintDebug(result)
+	cheBroker.PubDone(result)
 	cheBroker.CloseConsumers()
 }
 

--- a/brokers/che-plugin-broker/cmd/config.json
+++ b/brokers/che-plugin-broker/cmd/config.json
@@ -1,0 +1,32 @@
+[
+{
+    "id": "che-service-plugin",
+    "version": "0.0.1",
+    "type": "Che plugin",
+    "name": "Che Samples REST API Sidecar Plugin",
+    "title": "Che Samples REST API Sidecar Plugin",
+    "description": "Che Plug-in with Theia plug-in and container definition providing a service",
+    "icon": "https://www.eclipse.org/che/images/ico/16x16.png",
+    "url": "https://github.com/ws-skeleton/che-service-plugin/releases/download/untagged-5c4c888ff2de8ae7a5e2/che-service-plugin.tar.gz"
+},
+{
+    "id": "org.eclipse.che.editor.theia",
+    "version": "1.0.0",
+    "type": "Che Editor",
+    "name": "theia-ide",
+    "title": "Eclipse Theia for Eclipse Che",
+    "description": "Eclipse Theia",
+    "icon": "https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true",
+    "url": "https://github.com/ws-skeleton/che-editor-theia/releases/download/untagged-2218dafda12e0786aa79/che-editor-plugin.tar.gz"
+},
+{
+    "id": "org.eclipse.che.editor.theia",
+    "version": "1.0.0",
+    "type": "Che Editor",
+    "name": "theia-ide",
+    "title": "Eclipse Theia for Eclipse Che",
+    "description": "Eclipse Theia",
+    "icon": "https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true",
+    "url": "https://raw.githubusercontent.com/ws-skeleton/che-editor-theia/master/etc/che-plugin.yaml"
+}
+]

--- a/brokers/che-plugin-broker/cmd/main.go
+++ b/brokers/che-plugin-broker/cmd/main.go
@@ -27,9 +27,12 @@ func main() {
 	cfg.Parse()
 	cfg.Print()
 
-	statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
 	cheBroker := broker.NewBroker()
-	cheBroker.PushEvents(statusTun)
+
+	if !cfg.DisablePushingToEndpoint {
+		statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
+		cheBroker.PushEvents(statusTun)
+	}
 
 	metas := cfg.ReadConfig()
 	cheBroker.Start(metas)

--- a/brokers/init/cmd/main.go
+++ b/brokers/init/cmd/main.go
@@ -28,10 +28,13 @@ func main() {
 	cfg.Parse()
 	cfg.Print()
 
-	statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
 	broker := common.NewBroker()
 	defer broker.CloseConsumers()
-	broker.PushEvents(statusTun, model.BrokerLogEventType)
+
+	if !cfg.DisablePushingToEndpoint {
+		statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
+		broker.PushEvents(statusTun, model.BrokerLogEventType)
+	}
 
 	broker.PrintInfo("Starting Init Plugin Broker")
 	// Clear any existing plugins from /plugins/

--- a/brokers/theia/broker.go
+++ b/brokers/theia/broker.go
@@ -83,7 +83,9 @@ func (broker *TheiaPluginBroker) Start(metas []model.PluginMeta) {
 	}
 
 	broker.PrintInfo("All plugins have been successfully processed")
-	broker.PubDone(string(pluginsBytes))
+	result := string(pluginsBytes)
+	broker.PrintDebug(result)
+	broker.PubDone(result)
 	broker.CloseConsumers()
 }
 

--- a/brokers/theia/cmd/config.json
+++ b/brokers/theia/cmd/config.json
@@ -1,0 +1,12 @@
+[
+{
+    "id": "org.eclipse.che.samples.container-fortune",
+    "version": "0.0.1",
+    "type": "Theia plugin",
+    "name": "Che-Samples-Fortune",
+    "title": "Che Samples Container Fortune Plugin",
+    "description": "Fortune plug-in running in its own container that provides the fortune tool",
+    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "url": "https://github.com/ws-skeleton/che-fortune-plugin/releases/download/untagged-bbffe2843692982f673b/che_fortune_plugin.theia"
+}
+]

--- a/brokers/theia/cmd/main.go
+++ b/brokers/theia/cmd/main.go
@@ -27,9 +27,12 @@ func main() {
 	cfg.Parse()
 	cfg.Print()
 
-	statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
 	theiaBroker := theia.NewBroker()
-	theiaBroker.PushEvents(statusTun)
+
+	if !cfg.DisablePushingToEndpoint {
+		statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
+		theiaBroker.PushEvents(statusTun)
+	}
 
 	metas := cfg.ReadConfig()
 	theiaBroker.Start(metas)

--- a/brokers/vscode/broker.go
+++ b/brokers/vscode/broker.go
@@ -79,7 +79,9 @@ func (broker *VSCodeExtensionBroker) Start(metas []model.PluginMeta) {
 	}
 
 	broker.PrintInfo("All plugins have been successfully processed")
-	broker.PubDone(string(pluginsBytes))
+	result := string(pluginsBytes)
+	broker.PrintDebug(result)
+	broker.PubDone(result)
 	broker.CloseConsumers()
 }
 

--- a/brokers/vscode/broker_test.go
+++ b/brokers/vscode/broker_test.go
@@ -69,6 +69,7 @@ func TestStart(t *testing.T) {
 	mocks := initMocks()
 
 	mocks.cb.On("PubStarted").Once()
+	mocks.cb.On("PrintDebug", mock.AnythingOfType("string"))
 	mocks.cb.On("PubDone", "null").Once()
 	mocks.cb.On("PrintInfo", mock.AnythingOfType("string"))
 	mocks.cb.On("PrintPlan", mock.AnythingOfType("[]model.PluginMeta")).Once()

--- a/brokers/vscode/cmd/config.json
+++ b/brokers/vscode/cmd/config.json
@@ -1,0 +1,15 @@
+[
+{
+    "id": "org.eclipse.che.vscode.k8s",
+    "version": "1.0.0",
+    "type": "VS Code extension",
+    "name": "k8s-plugin",
+    "title": "k8s extension",
+    "description": "k8s extension",
+    "icon": "https://www.eclipse.org/che/images/ico/16x16.png",
+    "attributes": {
+	"extension": "vscode:extension/ms-kubernetes-tools.vscode-kubernetes-tools",
+	"container-image": "garagatyi/remotetheia:kubectl"
+    }
+}
+]

--- a/brokers/vscode/cmd/main.go
+++ b/brokers/vscode/cmd/main.go
@@ -27,9 +27,12 @@ func main() {
 	cfg.Parse()
 	cfg.Print()
 
-	statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
 	broker := vscode.NewBroker()
-	broker.PushEvents(statusTun)
+
+	if !cfg.DisablePushingToEndpoint {
+		statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)
+		broker.PushEvents(statusTun)
+	}
 
 	metas := cfg.ReadConfig()
 	broker.Start(metas)

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -40,6 +40,9 @@ var (
 	// RuntimeID the id of workspace runtime this machine belongs to.
 	RuntimeID    model.RuntimeID
 	runtimeIDRaw string
+
+	// DisablePushingToEndpoint disables pushing anything to the endpoint
+	DisablePushingToEndpoint bool
 )
 
 func init() {
@@ -79,18 +82,27 @@ func init() {
 		"",
 		"The identifier of the runtime in format 'workspace:environment:ownerId'",
 	)
+	flag.BoolVar(
+		&DisablePushingToEndpoint,
+		"disable-push",
+		false,
+		"whether pushing of data to endpoint should be disabled. "+
+			"`false` by default. Existing for testing and debugging purposes",
+	)
 }
 
 // Parse parses configuration.
 func Parse() {
 	flag.Parse()
 
-	// push-endpoint
-	if len(PushStatusesEndpoint) == 0 {
-		log.Fatal("Push endpoint required(set it with -push-endpoint argument)")
-	}
-	if !strings.HasPrefix(PushStatusesEndpoint, "ws") {
-		log.Fatal("Push endpoint protocol must be either ws or wss")
+	if !DisablePushingToEndpoint {
+		// push-endpoint
+		if len(PushStatusesEndpoint) == 0 {
+			log.Fatal("Push endpoint required(set it with -push-endpoint argument)")
+		}
+		if !strings.HasPrefix(PushStatusesEndpoint, "ws") {
+			log.Fatal("Push endpoint protocol must be either ws or wss")
+		}
 	}
 
 	// auth-enabled - fetch CHE_MACHINE_TOKEN
@@ -112,13 +124,14 @@ func Parse() {
 // Print prints configuration.
 func Print() {
 	log.Print("Broker configuration")
-	log.Printf("  Push endpoint: %s", PushStatusesEndpoint)
-	log.Printf("  Auth enabled: %t", AuthEnabled)
+	if !DisablePushingToEndpoint {
+		log.Printf("  Push endpoint: %s", PushStatusesEndpoint)
+		log.Printf("  Auth enabled: %t", AuthEnabled)
+	}
 	log.Print("  Runtime ID:")
 	log.Printf("    Workspace: %s", RuntimeID.Workspace)
 	log.Printf("    Environment: %s", RuntimeID.Environment)
 	log.Printf("    OwnerId: %s", RuntimeID.OwnerId)
-
 }
 
 // ReadConfig reads content of file by path cfg.FilePath,


### PR DESCRIPTION
### What does this PR do?
Now figuring out what went wrong with a plugin broker is quite painful.
This PR introduces changes that allow trying broker locally, debug it or so.
Changes:
- Add `-disable-push` option to brokers to run brokers without connecting to Workspace Master.
- Add printing of evaluated sidecar config to brokers right before exiting 
- Add examples of the configuration of brokers, so they can be easily tried locally.