### PR TITLE
Add the mountSources attribute to the container model.

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -101,6 +101,7 @@ type Container struct {
 	Volumes        []Volume        `json:"volumes" yaml:"volumes"`
 	Ports          []ExposedPort   `json:"ports" yaml:"ports"`
 	MemoryLimit    string          `json:"memory-limit" yaml:"memory-limit"`
+	MountSources   bool            `json:"mountSources" yaml:"mountSources"`
 }
 
 type Editor struct {


### PR DESCRIPTION
### What does this PR do?
This adds the new `mountSources` boolean attribute to the containers in the plugin model.
The default value is false, which is what we want here actually.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12510