### PR TITLE
Download VS Code extensions by url

### DIFF
--- a/brokers/vscode/cmd/config.json
+++ b/brokers/vscode/cmd/config.json
@@ -11,5 +11,18 @@
 	"extension": "vscode:extension/ms-kubernetes-tools.vscode-kubernetes-tools",
 	"containerImage": "garagatyi/remotetheia:kubectl"
     }
+},
+{
+    "id": "ms-vscode.typescript",
+    "version": "1.0.0",
+    "type": "VS Code extension",
+    "name": "Typescript",
+    "title": "Typescript language features",
+    "description": "Typescript language features",
+    "icon": "https://www.eclipse.org/che/images/ico/16x16.png",
+    "url": "https://github.com/tolusha/ms-code.typescript/releases/download/1.0.0/che-typescript-language.vsix",
+    "attributes": {
+	"containerImage": "garagatyi/remotetheia:kubectl"
+    }
 }
 ]


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### What does this PR do?
PR allows VS Code plugins broker to download extensions directly by url

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12549