### PR TITLE
Add ability to configure several extensions in a single VS Code plugin

### DIFF
--- a/brokers/theia/sidecar.go
+++ b/brokers/theia/sidecar.go
@@ -20,17 +20,47 @@ import (
 	"github.com/eclipse/che-plugin-broker/model"
 )
 
+var re = regexp.MustCompile(`[^a-zA-Z_0-9]+`)
+
+// GenerateSidecarTooling generates Theia plugin runner sidecar and adds a single plugin to it
+// Deprecated: use GenerateSidecar + AddExtension instead
 func GenerateSidecarTooling(image string, pj model.PackageJSON, rand common.Random) *model.ToolingConf {
-	tooling := &model.ToolingConf{
-		Containers: []model.Container{*containerConfig(image, rand)},
-	}
-	addPortToTooling(tooling, pj, rand)
+	tooling := &model.ToolingConf{}
+	tooling.Containers = append(tooling.Containers, containerConfig(image, rand))
+	endpoint := generateTheiaSidecarEndpoint(rand)
+	setEndpoint(tooling, endpoint)
+	AddExtension(tooling, pj)
 
 	return tooling
 }
 
-func containerConfig(image string, rand common.Random) *model.Container {
-	c := model.Container{
+// GenerateSidecar generates sidecar tooling configuration.
+// Plugins can be added to the configuration using function AddExtension
+func GenerateSidecar(image string, rand common.Random) *model.ToolingConf {
+	tooling := &model.ToolingConf{}
+	tooling.Containers = append(tooling.Containers, containerConfig(image, rand))
+	endpoint := generateTheiaSidecarEndpoint(rand)
+	setEndpoint(tooling, endpoint)
+
+	return tooling
+}
+
+// AddExtension adds to tooling an environment variable needed for extension to be consumed by Theia.
+// Environment variable uses extension name and publisher specified in PackageJSON.
+// Extension publisher and plugin name taken by retrieving info from package.json and replacing all
+// chars matching [^a-z_0-9]+ with a dash character
+func AddExtension(toolingConf *model.ToolingConf, pj model.PackageJSON) {
+	sidecarEndpoint := toolingConf.Endpoints[0]
+	prettyID := re.ReplaceAllString(pj.Publisher+"_"+pj.Name, `_`)
+	sidecarTheiaEnvVarName := "THEIA_PLUGIN_REMOTE_ENDPOINT_" + prettyID
+	sidecarTheiaEnvVarValue := "ws://" + sidecarEndpoint.Name + ":" + strconv.Itoa(sidecarEndpoint.TargetPort)
+
+	toolingConf.WorkspaceEnv = append(toolingConf.WorkspaceEnv, model.EnvVar{Name: sidecarTheiaEnvVarName, Value: sidecarTheiaEnvVarValue})
+}
+
+// Generates sidecar container config with needed image and volumes
+func containerConfig(image string, rand common.Random) model.Container {
+	return model.Container{
 		Name:  "pluginsidecar" + rand.String(6),
 		Image: image,
 		Volumes: []model.Volume{
@@ -44,31 +74,24 @@ func containerConfig(image string, rand common.Random) *model.Container {
 			},
 		},
 	}
-	return &c
 }
 
-// addPortToTooling adds to tooling everything needed to start Theia remote plugin:
-// - Random port to the container (one and only)
-// - Endpoint matching the port
-// - Environment variable THEIA_PLUGIN_ENDPOINT_PORT to the container with the port as value
-// - Environment variable that start from THEIA_PLUGIN_REMOTE_ENDPOINT_ and ends with
-// plugin publisher and plugin name taken from packageJson and replacing all
-// chars matching [^a-z_0-9]+ with a dash character
-func addPortToTooling(toolingConf *model.ToolingConf, pj model.PackageJSON, rand common.Random) {
-	port := rand.IntFromRange(4000, 10000)
-	sPort := strconv.Itoa(port)
+// Generates random non-publicly exposed endpoint for sidecar to allow Theia connecting to it
+func generateTheiaSidecarEndpoint(rand common.Random) model.Endpoint {
 	endpointName := rand.String(10)
-	var re = regexp.MustCompile(`[^a-zA-Z_0-9]+`)
-	prettyID := re.ReplaceAllString(pj.Publisher+"_"+pj.Name, `_`)
-	sidecarTheiaEnvVarName := "THEIA_PLUGIN_REMOTE_ENDPOINT_" + prettyID
-	sidecarTheiaEnvVarValue := "ws://" + endpointName + ":" + sPort
-
-	toolingConf.Containers[0].Ports = append(toolingConf.Containers[0].Ports, model.ExposedPort{ExposedPort: port})
-	toolingConf.Endpoints = append(toolingConf.Endpoints, model.Endpoint{
+	port := rand.IntFromRange(4000, 10000)
+	return model.Endpoint{
 		Name:       endpointName,
 		Public:     false,
 		TargetPort: port,
-	})
-	toolingConf.Containers[0].Env = append(toolingConf.Containers[0].Env, model.EnvVar{Name: "THEIA_PLUGIN_ENDPOINT_PORT", Value: sPort})
-	toolingConf.WorkspaceEnv = append(toolingConf.WorkspaceEnv, model.EnvVar{Name: sidecarTheiaEnvVarName, Value: sidecarTheiaEnvVarValue})
+	}
+}
+
+// Sets sidecar endpoint into tooling and adds needed port exposure and environment variable to the sidecar container
+// to run plugin runner Theia slave on a port specified in provided endpoint
+func setEndpoint(toolingConf *model.ToolingConf, endpoint model.Endpoint) {
+	port := endpoint.TargetPort
+	toolingConf.Containers[0].Ports = append(toolingConf.Containers[0].Ports, model.ExposedPort{ExposedPort: port})
+	toolingConf.Endpoints = append(toolingConf.Endpoints, endpoint)
+	toolingConf.Containers[0].Env = append(toolingConf.Containers[0].Env, model.EnvVar{Name: "THEIA_PLUGIN_ENDPOINT_PORT", Value: strconv.Itoa(port)})
 }

--- a/brokers/theia/sidecar_test.go
+++ b/brokers/theia/sidecar_test.go
@@ -1,0 +1,181 @@
+//
+// Copyright (c) 2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package theia
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/eclipse/che-plugin-broker/common/mocks"
+	"github.com/eclipse/che-plugin-broker/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateSidecar(t *testing.T) {
+	testImage := "test/test:latest"
+	random6 := "123456"
+	random10 := "1234567890"
+	randomInt := 8889
+	rand := &mocks.Random{}
+	rand.On("String", 6).Return(random6)
+	rand.On("String", 10).Return(random10)
+	rand.On("IntFromRange", 4000, 10000).Return(randomInt)
+
+	expected := generateTestToolingWithVars(testImage, random6, randomInt, random10)
+
+	actual := GenerateSidecar(testImage, rand)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestAddExtension(t *testing.T) {
+	type args struct {
+		toolingConf *model.ToolingConf
+		pj          model.PackageJSON
+	}
+	tests := []struct {
+		name string
+		args args
+		want *model.ToolingConf
+	}{
+		{
+			name: "Test adding extension with package.json data with a-zA-Z0-9_ symbols",
+			args: args{
+				toolingConf: generateTestTooling(),
+				pj:          generatePackageJSON("pluginName8", "publisherName1_0_"),
+			},
+			want: generateTestToolingWithExtension("pluginName8", "publisherName1_0_"),
+		},
+		{
+			name: "Test adding extension with package.json data with # symbol",
+			args: args{
+				toolingConf: generateTestTooling(),
+				pj:          generatePackageJSON("plugin#Name8", "publisherName1_0_"),
+			},
+			want: generateTestToolingWithExtension("plugin_Name8", "publisherName1_0_"),
+		},
+		{
+			name: "Test adding extension with package.json data with @ symbol",
+			args: args{
+				toolingConf: generateTestTooling(),
+				pj:          generatePackageJSON("plu@ginName8", "publisherName1_0_"),
+			},
+			want: generateTestToolingWithExtension("plu_ginName8", "publisherName1_0_"),
+		},
+		{
+			name: "Test adding extension with package.json data with : symbol",
+			args: args{
+				toolingConf: generateTestTooling(),
+				pj:          generatePackageJSON("pluginName8", "publisherName:1_0_"),
+			},
+			want: generateTestToolingWithExtension("pluginName8", "publisherName_1_0_"),
+		},
+		{
+			name: "Test adding extension with package.json data with ? symbol",
+			args: args{
+				toolingConf: generateTestTooling(),
+				pj:          generatePackageJSON("pluginName8", "publisherName?1_0_"),
+			},
+			want: generateTestToolingWithExtension("pluginName8", "publisherName_1_0_"),
+		},
+		{
+			name: "Test adding extension with package.json data with - symbol",
+			args: args{
+				toolingConf: generateTestTooling(),
+				pj:          generatePackageJSON("plugin-Name-8", "publisherName1_0_"),
+			},
+			want: generateTestToolingWithExtension("plugin_Name_8", "publisherName1_0_"),
+		},
+		{
+			name: "Test adding extension with package.json data with ! symbol",
+			args: args{
+				toolingConf: generateTestTooling(),
+				pj:          generatePackageJSON("plugin!Name8", "publisherName1_0_!"),
+			},
+			want: generateTestToolingWithExtension("plugin_Name8", "publisherName1_0__"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddExtension(tt.args.toolingConf, tt.args.pj)
+		})
+		assert.Equal(t, tt.args.toolingConf, tt.want)
+	}
+}
+
+func generatePackageJSON(name string, publisher string) model.PackageJSON {
+	return model.PackageJSON{
+		Name:      name,
+		Publisher: publisher,
+	}
+}
+
+func generateTestToolingWithExtension(extName string, extPublisher string) *model.ToolingConf {
+	testImage := "test/test:latest"
+	random6 := "123456"
+	random10 := "1234567890"
+	randomInt := 8889
+	tooling := generateTestToolingWithVars(testImage, random6, randomInt, random10)
+	tooling.WorkspaceEnv = append(tooling.WorkspaceEnv, model.EnvVar{
+		Name:  "THEIA_PLUGIN_REMOTE_ENDPOINT_" + extPublisher + "_" + extName,
+		Value: "ws://" + random10 + ":" + strconv.Itoa(randomInt),
+	})
+	return tooling
+}
+
+func generateTestTooling() *model.ToolingConf {
+	testImage := "test/test:latest"
+	random6 := "123456"
+	random10 := "1234567890"
+	randomInt := 8889
+	return generateTestToolingWithVars(testImage, random6, randomInt, random10)
+}
+
+func generateTestToolingWithVars(testImage string, nameSuffix string, port int, endpointName string) *model.ToolingConf {
+	return &model.ToolingConf{
+		Containers: []model.Container{
+			{
+				Name:  "pluginsidecar" + nameSuffix,
+				Image: testImage,
+				Volumes: []model.Volume{
+					{
+						Name:      "projects",
+						MountPath: "/projects",
+					},
+					{
+						Name:      "plugins",
+						MountPath: "/plugins",
+					},
+				},
+				Ports: []model.ExposedPort{
+					{
+						ExposedPort: port,
+					},
+				},
+				Env: []model.EnvVar{
+					{
+						Name:  "THEIA_PLUGIN_ENDPOINT_PORT",
+						Value: strconv.Itoa(port),
+					},
+				},
+			},
+		},
+		Endpoints: []model.Endpoint{
+			{
+				Name:       endpointName,
+				Public:     false,
+				TargetPort: port,
+			},
+		},
+	}
+}

--- a/brokers/vscode/broker.go
+++ b/brokers/vscode/broker.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/eclipse/che-go-jsonrpc"
@@ -34,6 +35,8 @@ import (
 const marketplace = "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery"
 const bodyFmt = `{"filters":[{"criteria":[{"filterType":7,"value":"%s"}],"pageNumber":1,"pageSize":1,"sortBy":0, "sortOrder":0 }],"assetTypes":["Microsoft.VisualStudio.Services.VSIXPackage"],"flags":131}`
 const assetType = "Microsoft.VisualStudio.Services.VSIXPackage"
+const errorMutuallyExclusiveExtFieldsTemplate = "VS Code extension description of the plugin '%s:%s' contains more than one mutually exclusive field 'attributes.extension', 'url', 'extensions'"
+const errorNoExtFieldsTemplate = "Neither 'extension' nor 'url' nor 'extensions' field found in VS Code extension description of the plugin '%s:%s'"
 
 // Broker is used to process VS Code extensions to run them as Che plugins
 type Broker struct {
@@ -97,16 +100,9 @@ func (b *Broker) PushEvents(tun *jsonrpc.Tunnel) {
 func (b *Broker) processPlugin(meta model.PluginMeta) error {
 	b.PrintDebug("Stared processing plugin '%s:%s'", meta.ID, meta.Version)
 
-	url := meta.URL
-	extension := ""
-	if meta.Attributes != nil {
-		extension = meta.Attributes["extension"]
-	}
-
-	if url == "" && extension == "" {
-		return fmt.Errorf("Neither 'extension' no 'url' attributes found in VS Code extension description of the plugin %s:%s", meta.ID, meta.Version)
-	} else if url != "" && extension != "" {
-		return fmt.Errorf("VS Code extension description of the plugin %s:%s might contain either 'extension' or 'url' attributes, but both of them are found", meta.ID, meta.Version)
+	URLs, err := b.getBinariesURLs(meta)
+	if err != nil {
+		return err
 	}
 
 	workDir, err := b.ioUtil.TempDir("", "vscode-extension-broker")
@@ -114,81 +110,162 @@ func (b *Broker) processPlugin(meta model.PluginMeta) error {
 		return err
 	}
 
-	archivePath := filepath.Join(workDir, "pluginArchive")
-
-	// Download an archive
-	if url != "" {
-		b.PrintDebug("Downloading VS Code extension archive '%s' for plugin '%s:%s' to '%s'", url, meta.ID, meta.Version, archivePath)
-		b.PrintInfo("Downloading VS Code extension for plugin '%s:%s'", meta.ID, meta.Version)
-		err = b.downloadArchive(url, archivePath)
-		if err != nil {
-			return err
-		}
-	} else {
-		b.PrintDebug("Downloading VS Code extension '%s' for plugin '%s:%s' to '%s'", extension, meta.ID, meta.Version, archivePath)
-		b.PrintInfo("Downloading VS Code extension for plugin '%s:%s'", meta.ID, meta.Version)
-		err = b.downloadExtension(extension, archivePath, meta)
-		if err != nil {
-			return err
-		}
+	archivesPaths, err := b.downloadArchives(URLs, meta, workDir)
+	if err != nil {
+		return err
 	}
 
 	image := meta.Attributes["containerImage"]
 	if image == "" {
 		// regular plugin
-		return b.injectLocalPlugin(meta, archivePath)
+		return b.injectLocalPlugin(meta, archivesPaths)
 	}
 	// remote plugin
-	return b.injectRemotePlugin(meta, image, archivePath, workDir)
+	return b.injectRemotePlugin(meta, image, archivesPaths, workDir)
 }
 
-func (b *Broker) injectLocalPlugin(meta model.PluginMeta, archivePath string) error {
-	b.PrintDebug("Copying VS Code extension '%s:%s'", meta.ID, meta.Version)
-	pluginPath := filepath.Join("/plugins", fmt.Sprintf("%s.%s.vsix", meta.ID, meta.Version))
-	err := b.ioUtil.CopyFile(archivePath, pluginPath)
-	if err != nil {
-		return err
+func (b *Broker) injectLocalPlugin(meta model.PluginMeta, archivesPaths []string) error {
+	b.PrintDebug("Copying VS Code plugin '%s:%s'", meta.ID, meta.Version)
+	for _, path := range archivesPaths {
+		pluginName := b.generatePluginArchiveName(meta)
+		pluginPath := filepath.Join("/plugins", pluginName)
+		b.PrintDebug("Copying VS Code extension archive from '%s' to '%s' for plugin '%s:%s'", path, pluginPath, meta.ID, meta.Version)
+		err := b.ioUtil.CopyFile(path, pluginPath)
+		if err != nil {
+			return err
+		}
 	}
+
 	tooling := &model.ToolingConf{}
 	return b.Storage.AddPlugin(&meta, tooling)
 }
 
-func (b *Broker) injectRemotePlugin(meta model.PluginMeta, image string, archivePath string, workDir string) error {
-	// Unzip it
-	unpackedPath := filepath.Join(workDir, "plugin")
-	b.PrintDebug("Unzipping archive '%s' for plugin '%s:%s' to '%s'", archivePath, meta.ID, meta.Version, unpackedPath)
-	err := b.ioUtil.Unzip(archivePath, unpackedPath)
-	if err != nil {
-		return err
+func (b *Broker) injectRemotePlugin(meta model.PluginMeta, image string, archivesPaths []string, workDir string) error {
+	tooling := theia.GenerateSidecar(image, b.rand)
+	for _, archive := range archivesPaths {
+		// Unzip it
+		unpackedPath := filepath.Join(workDir, "extension", b.rand.String(10))
+		b.PrintDebug("Unzipping archive '%s' for plugin '%s:%s' to '%s'", archive, meta.ID, meta.Version, unpackedPath)
+		err := b.ioUtil.Unzip(archive, unpackedPath)
+		if err != nil {
+			return err
+		}
+
+		pj, err := b.getPackageJSON(unpackedPath)
+		if err != nil {
+			return err
+		}
+
+		pluginName := b.generatePluginFolderName(meta, *pj)
+
+		pluginFolderPath := filepath.Join("/plugins", pluginName)
+		b.PrintDebug("Copying VS Code extension '%s:%s' from '%s' to '%s'", meta.ID, meta.Version, unpackedPath, pluginFolderPath)
+		err = b.ioUtil.CopyResource(unpackedPath, pluginFolderPath)
+		if err != nil {
+			return err
+		}
+		theia.AddExtension(tooling, *pj)
 	}
 
-	pj, err := b.getPackageJSON(unpackedPath)
-	if err != nil {
-		return err
-	}
-
-	pluginFolderPath := filepath.Join("/plugins", fmt.Sprintf("%s.%s", meta.ID, meta.Version))
-	b.PrintDebug("Copying VS Code extension '%s:%s' from '%s' to '%s'", meta.ID, meta.Version, unpackedPath, pluginFolderPath)
-	err = b.ioUtil.CopyResource(unpackedPath, pluginFolderPath)
-	if err != nil {
-		return err
-	}
-	tooling := theia.GenerateSidecarTooling(image, *pj, b.rand)
 	return b.Storage.AddPlugin(&meta, tooling)
 }
 
-func (b *Broker) downloadExtension(extension string, dest string, meta model.PluginMeta) error {
+func (b *Broker) downloadArchives(URLs []string, meta model.PluginMeta, workDir string) ([]string, error) {
+	paths := make([]string, 0)
+	for _, URL := range URLs {
+		archivePath := filepath.Join(workDir, "pluginArchive"+b.rand.String(10))
+		b.PrintDebug("Downloading VS Code extension archive '%s' for plugin '%s:%s' to '%s'", URL, meta.ID, meta.Version, archivePath)
+		b.PrintInfo("Downloading VS Code extension for plugin '%s:%s'", meta.ID, meta.Version)
+		err := b.downloadArchive(URL, archivePath)
+		paths = append(paths, archivePath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return paths, nil
+}
+
+func (b *Broker) getExtensionsAndURLs(meta model.PluginMeta) (e []string, u []string, err error) {
+	extensions := make([]string, 0)
+	URLs := make([]string, 0)
+	isSet := false
+
+	if meta.URL != "" {
+		isSet = true
+		URLs = append(URLs, meta.URL)
+	}
+	if meta.Attributes != nil && meta.Attributes["extension"] != "" {
+		if isSet {
+			return nil, nil, fmt.Errorf(errorMutuallyExclusiveExtFieldsTemplate, meta.ID, meta.Version)
+		}
+		isSet = true
+		extensions = append(extensions, meta.Attributes["extension"])
+	}
+	if meta.Extensions != nil && len(meta.Extensions) != 0 {
+		if isSet {
+			return nil, nil, fmt.Errorf(errorMutuallyExclusiveExtFieldsTemplate, meta.ID, meta.Version)
+		}
+		isSet = true
+		for _, v := range meta.Extensions {
+			ext, URL := extensionOrURL(v)
+			switch {
+			case ext != "":
+				extensions = append(extensions, ext)
+			case URL != "":
+				URLs = append(URLs, URL)
+			}
+		}
+	}
+	if !isSet {
+		return nil, nil, fmt.Errorf(errorNoExtFieldsTemplate, meta.ID, meta.Version)
+	}
+	return extensions, URLs, nil
+}
+
+func (b *Broker) getBinariesURLs(meta model.PluginMeta) ([]string, error) {
+	extensions, URLs, err := b.getExtensionsAndURLs(meta)
+	if err != nil {
+		return nil, err
+	}
+	for _, ext := range extensions {
+		URL, err := b.getExtensionArchiveURL(ext, meta)
+		if err != nil {
+			return nil, err
+		}
+		URLs = append(URLs, URL)
+	}
+	return URLs, nil
+}
+
+func extensionOrURL(extensionOrURL string) (extension string, URL string) {
+	if strings.HasPrefix(extensionOrURL, "vscode:extension/") {
+		return extensionOrURL, ""
+	} else {
+		return "", extensionOrURL
+	}
+}
+
+func (b *Broker) generatePluginFolderName(meta model.PluginMeta, pj model.PackageJSON) string {
+	var re = regexp.MustCompile(`[^a-zA-Z_0-9]+`)
+	prettyID := re.ReplaceAllString(pj.Publisher+"_"+pj.Name, "")
+	return fmt.Sprintf("%s.%s.%s", meta.ID, meta.Version, prettyID)
+}
+
+func (b *Broker) generatePluginArchiveName(meta model.PluginMeta) string {
+	return fmt.Sprintf("%s.%s.%s.vsix", meta.ID, meta.Version, b.rand.String(10))
+}
+
+func (b *Broker) getExtensionArchiveURL(extension string, meta model.PluginMeta) (string, error) {
 	response, err := b.fetchExtensionInfo(extension, meta)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	URL, err := findAssetURL(response, meta)
 	if err != nil {
-		return err
+		return "", err
 	}
-
-	return b.downloadArchive(URL, dest)
+	return URL, nil
 }
 
 func (b *Broker) downloadArchive(URL string, dest string) error {
@@ -222,7 +299,7 @@ func (b *Broker) fetchExtensionInfo(extension string, meta model.PluginMeta) ([]
 	re := regexp.MustCompile(`^vscode:extension/(.*)`)
 	groups := re.FindStringSubmatch(extension)
 	if len(groups) != 2 {
-		return nil, fmt.Errorf("VS Code extension id '%s' parsing failed for plugin %s:%s", extension, meta.ID, meta.Version)
+		return nil, fmt.Errorf("Parsing of VS Code extension ID '%s' failed for plugin '%s:%s'. Extension should start from 'vscode:extension/'", extension, meta.ID, meta.Version)
 	}
 	extName := groups[1]
 	body := []byte(fmt.Sprintf(bodyFmt, extName))

--- a/brokers/vscode/cmd/manual-testing-several-extensions-in-one-plugin.json
+++ b/brokers/vscode/cmd/manual-testing-several-extensions-in-one-plugin.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "org.eclipse.che.vscode-redhat.java-and-yaml-in-sidecar",
+    "version": "0.38.0",
+    "type": "VS Code extension",
+    "name": "Language Support for Java(TM)",
+    "title": "Language Support for Java(TM) by Red Hat",
+    "description": "Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...",
+    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "publisher": "Red Hat, Inc.",
+    "repository": "https://github.com/redhat-developer/vscode-java",
+    "category": "Language",
+    "firstPublicationDate": "2019-02-20",
+    "extensions": [
+      "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/vscode-yaml/0.3.0/vspackage",
+      "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage",
+      "vscode:extension/redhat.vscode-xml"
+    ],
+    "attributes": {
+      "containerImage": "eclipse/che-remote-plugin-runner-java8:nightly"
+    }
+  },
+  {
+    "id": "org.eclipse.che.vscode-redhat.java-and-yaml-local",
+    "version": "0.38.0",
+    "type": "VS Code extension",
+    "name": "Language Support for Java(TM)",
+    "title": "Language Support for Java(TM) by Red Hat",
+    "description": "Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...",
+    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "publisher": "Red Hat, Inc.",
+    "repository": "https://github.com/redhat-developer/vscode-java",
+    "category": "Language",
+    "firstPublicationDate": "2019-02-20",
+    "extensions": [
+      "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/vscode-yaml/0.3.0/vspackage",
+      "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage",
+      "vscode:extension/redhat.vscode-xml"
+    ]
+  }
+]

--- a/model/model.go
+++ b/model/model.go
@@ -64,6 +64,8 @@ type PluginMeta struct {
 	URL string `json:"url" yaml:"url"`
 
 	Attributes map[string]string `json:"attributes" yaml:"attributes"`
+
+	Extensions []string `json:"extensions" yaml:"extensions"`
 }
 
 type Endpoint struct {


### PR DESCRIPTION
### What does this PR do?
This PR is designed to be reviewed in a commit-by-commit manner. This simplifies diffs of commits significantly and doesn't shuffle them.
Add ability to configure several extensions in a single VS Code plugin.
Both URLs and extension IDs are supported.
Format:
```yaml
id: blah
version: blah
attributes:
  blah
extensions:  
 - vscode:extension/SonarSource.sonarlint-vscode
 - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage
 - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/vscode-xml/0.3.0/vspackage
```
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12395
