### PR TITLE
Make unified broker accept list of plugins ID:version s and download meta.yaml from plugin registry

### DIFF
--- a/brokers/che-plugin-broker/broker.go
+++ b/brokers/che-plugin-broker/broker.go
@@ -23,12 +23,12 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/eclipse/che-go-jsonrpc"
+	jsonrpc "github.com/eclipse/che-go-jsonrpc"
+	"github.com/eclipse/che-plugin-broker/cfg"
 	"github.com/eclipse/che-plugin-broker/common"
 	"github.com/eclipse/che-plugin-broker/model"
 	"github.com/eclipse/che-plugin-broker/storage"
 	"github.com/eclipse/che-plugin-broker/utils"
-	"github.com/eclipse/che-plugin-broker/cfg"
 )
 
 const pluginFileName = "che-plugin.yaml"
@@ -43,13 +43,6 @@ const (
 	Yaml
 )
 
-// ChePluginBroker is used to process Che plugins
-type ChePluginBroker interface {
-	Start([]model.PluginMeta)
-	PushEvents(tun *jsonrpc.Tunnel)
-	ProcessPlugin(meta model.PluginMeta) error
-}
-
 type chePluginBrokerImpl struct {
 	common.Broker
 	ioUtil  utils.IoUtil
@@ -57,7 +50,7 @@ type chePluginBrokerImpl struct {
 }
 
 // NewBroker creates Che plugin broker instance
-func NewBroker() ChePluginBroker {
+func NewBroker() common.BrokerImpl {
 	return &chePluginBrokerImpl{
 		common.NewBroker(),
 		utils.New(),
@@ -65,8 +58,8 @@ func NewBroker() ChePluginBroker {
 	}
 }
 
-// NewBroker creates Che plugin broker instance
-func NewBrokerWithParams(broker common.Broker, ioUtil utils.IoUtil, storage *storage.Storage) ChePluginBroker {
+// NewBrokerWithParams creates Che plugin broker instance
+func NewBrokerWithParams(broker common.Broker, ioUtil utils.IoUtil, storage *storage.Storage) common.BrokerImpl {
 	return &chePluginBrokerImpl{
 		Broker:  broker,
 		ioUtil:  ioUtil,
@@ -191,7 +184,7 @@ func (cheBroker *chePluginBrokerImpl) processArchive(meta *model.PluginMeta, url
 	if cfg.OnlyApplyMetadataActions {
 		return nil
 	}
-	
+
 	cheBroker.PrintDebug("Copying dependencies for '%s:%s'", meta.ID, meta.Version)
 	return cheBroker.copyDependencies(pluginPath)
 }

--- a/brokers/theia/broker.go
+++ b/brokers/theia/broker.go
@@ -18,20 +18,13 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/eclipse/che-go-jsonrpc"
+	jsonrpc "github.com/eclipse/che-go-jsonrpc"
+	"github.com/eclipse/che-plugin-broker/cfg"
 	"github.com/eclipse/che-plugin-broker/common"
 	"github.com/eclipse/che-plugin-broker/model"
 	"github.com/eclipse/che-plugin-broker/storage"
 	"github.com/eclipse/che-plugin-broker/utils"
-	"github.com/eclipse/che-plugin-broker/cfg"
 )
-
-// Broker is used to process .theia and remote plugins
-type Broker interface {
-	Start(metas []model.PluginMeta)
-	PushEvents(tun *jsonrpc.Tunnel)
-	ProcessPlugin(meta model.PluginMeta) error
-}
 
 type brokerImpl struct {
 	common.Broker
@@ -41,7 +34,7 @@ type brokerImpl struct {
 }
 
 // NewBroker creates Che Theia plugin broker instance
-func NewBroker() Broker {
+func NewBroker() common.BrokerImpl {
 	return &brokerImpl{
 		Broker:  common.NewBroker(),
 		ioUtil:  utils.New(),
@@ -50,8 +43,8 @@ func NewBroker() Broker {
 	}
 }
 
-// NewBroker creates Che Theia plugin broker instance
-func NewBrokerWithParams(broker common.Broker, ioUtil utils.IoUtil, storage *storage.Storage, rand common.Random) Broker {
+// NewBrokerWithParams creates Che Theia plugin broker instance
+func NewBrokerWithParams(broker common.Broker, ioUtil utils.IoUtil, storage *storage.Storage, rand common.Random) common.BrokerImpl {
 	return &brokerImpl{
 		Broker:  broker,
 		ioUtil:  ioUtil,
@@ -147,7 +140,7 @@ func (b *brokerImpl) ProcessPlugin(meta model.PluginMeta) error {
 	}
 	if pluginImage == "" {
 		// regular plugin
-		if (! cfg.OnlyApplyMetadataActions) {
+		if !cfg.OnlyApplyMetadataActions {
 			err = b.injectTheiaFile(meta, archivePath)
 			if err != nil {
 				return err
@@ -188,7 +181,7 @@ func (b *brokerImpl) injectTheiaFile(meta model.PluginMeta, archivePath string) 
 }
 
 func (b *brokerImpl) injectTheiaRemotePlugin(meta model.PluginMeta, archiveFolder string, image string, pj *PackageJSON) error {
-	if (! cfg.OnlyApplyMetadataActions) {
+	if !cfg.OnlyApplyMetadataActions {
 		pluginFolderPath := filepath.Join("/plugins", fmt.Sprintf("%s.%s", meta.ID, meta.Version))
 		b.PrintDebug("Copying Theia remote plugin '%s:%s' from '%s' to '%s'", meta.ID, meta.Version, archiveFolder, pluginFolderPath)
 		err := b.ioUtil.CopyResource(archiveFolder, pluginFolderPath)

--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -37,9 +37,9 @@ type Broker struct {
 	common.Broker
 	Storage *storage.Storage
 
-	theiaBroker  theia.Broker
-	vscodeBroker vscode.Broker
-	cheBroker    broker.ChePluginBroker
+	theiaBroker  common.BrokerImpl
+	vscodeBroker common.BrokerImpl
+	cheBroker    common.BrokerImpl
 }
 
 // NewBroker creates Che broker instance

--- a/brokers/unified/cmd/config-plugin-ids.json
+++ b/brokers/unified/cmd/config-plugin-ids.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "ms-kubernetes-tools.vscode-kubernetes-tools",
+    "version": "0.1.17"
+  },
+  {
+    "id": "che-machine-exec-plugin",
+    "version": "0.0.1"
+  },
+  {
+    "id": "org.eclipse.che.vscode-redhat.java",
+    "version": "0.38.0",
+    "registry": "https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/plugins/"
+  }
+]

--- a/brokers/unified/cmd/main.go
+++ b/brokers/unified/cmd/main.go
@@ -34,6 +34,17 @@ func main() {
 		broker.PushEvents(statusTun)
 	}
 
-	metas := cfg.ReadConfig()
-	broker.Start(metas)
+	if cfg.DownloadMetas {
+		pluginFQNs, err := cfg.ParsePluginFQNs()
+		if err != nil {
+			broker.PrintFatal("Failed to process plugin fully qualified names from config: %s", err)
+		}
+		broker.DownloadMetasAndStart(pluginFQNs, cfg.RegistryAddress)
+	} else {
+		pluginMetas, err := cfg.ReadConfig()
+		if err != nil {
+			broker.PrintFatal("Failed to process plugin fully qualified names from config: %s", err)
+		}
+		broker.Start(pluginMetas)
+	}
 }

--- a/common/broker.go
+++ b/common/broker.go
@@ -13,10 +13,18 @@
 package common
 
 import (
-	"github.com/eclipse/che-go-jsonrpc"
+	jsonrpc "github.com/eclipse/che-go-jsonrpc"
 	"github.com/eclipse/che-go-jsonrpc/event"
 	"github.com/eclipse/che-plugin-broker/model"
 )
+
+// BrokerImpl specifies the interface for a Broker implementation that processes
+// plugins of a specific type
+type BrokerImpl interface {
+	Start([]model.PluginMeta)
+	PushEvents(tun *jsonrpc.Tunnel)
+	ProcessPlugin(meta model.PluginMeta) error
+}
 
 // Broker holds utilities to interact with Che master to push different events
 type Broker interface {

--- a/model/model.go
+++ b/model/model.go
@@ -68,6 +68,12 @@ type PluginMeta struct {
 	Extensions []string `json:"extensions" yaml:"extensions"`
 }
 
+type PluginFQN struct {
+	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	ID       string `json:"id" yaml:"id"`
+	Version  string `json:"version" yaml:"version"`
+}
+
 type Endpoint struct {
 	Name       string            `json:"name" yaml:"name"`
 	Public     bool              `json:"public" yaml:"public"`
@@ -184,6 +190,6 @@ func (e *PluginBrokerLogEvent) Type() string { return BrokerLogEventType }
 
 // PackageJSON represents package.json file of JS based projects
 type PackageJSON struct {
-	Name      string  `json:"name" yaml:"name"`
-	Publisher string  `json:"publisher" yaml:"publisher"`
+	Name      string `json:"name" yaml:"name"`
+	Publisher string `json:"publisher" yaml:"publisher"`
 }

--- a/utils/ioutil_test.go
+++ b/utils/ioutil_test.go
@@ -1,0 +1,135 @@
+//
+// Copyright (c) 2018-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package utils
+
+import (
+	"errors"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/eclipse/che-plugin-broker/utils/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+const expectedResponseBody = "Test body"
+
+func TestIoUtil_Fetch(t *testing.T) {
+	type args struct {
+		URL string
+	}
+	type want struct {
+		expected  []byte
+		errRegexp *regexp.Regexp
+	}
+	type clientMocks struct {
+		response *http.Response
+		isClosed func() bool
+		err      error
+	}
+
+	generateMocks := func(body string, status int, err error, failRequest bool) clientMocks {
+		var response *http.Response
+		var isClosed func() bool
+		if failRequest {
+			response, isClosed = mocks.GenerateErrorResponse(body, status)
+		} else {
+			response, isClosed = mocks.GenerateResponse(body, status)
+		}
+		return clientMocks{
+			response: response,
+			err:      err,
+			isClosed: isClosed,
+		}
+	}
+
+	tests := []struct {
+		name  string
+		args  args
+		mocks clientMocks
+		want  want
+	}{
+		{
+			name: "Returns error when Get returns error",
+			args: args{
+				URL: "test.url",
+			},
+			want: want{
+				expected:  nil,
+				errRegexp: regexp.MustCompile("failed to get data from .*"),
+			},
+			mocks: generateMocks("testBody", http.StatusForbidden, errors.New("TestError"), false),
+		},
+		{
+			name: "Returns error when http request not status OK",
+			args: args{
+				URL: "test.url",
+			},
+			want: want{
+				expected:  nil,
+				errRegexp: regexp.MustCompile("Downloading .* failed. Status code .*"),
+			},
+			mocks: generateMocks("testBody", http.StatusForbidden, nil, false),
+		},
+		{
+			name: "Returns error when read body results in error",
+			args: args{
+				URL: "test.url",
+			},
+			want: want{
+				expected:  nil,
+				errRegexp: regexp.MustCompile("failed to read response body: .*"),
+			},
+			mocks: generateMocks("testBody", http.StatusOK, nil, true),
+		},
+		{
+			name: "Returns data from response",
+			args: args{
+				URL: "test.url",
+			},
+			want: want{
+				expected:  []byte(expectedResponseBody),
+				errRegexp: nil,
+			},
+			mocks: generateMocks(expectedResponseBody, http.StatusOK, nil, false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			util := &impl{
+				mocks.NewTestHTTPClient(tt.mocks.response, tt.mocks.err),
+			}
+			actual, err := util.Fetch(tt.args.URL)
+			if tt.want.errRegexp != nil {
+				assertErrorMatches(t, tt.want.errRegexp, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.want.expected != nil {
+				assert.Equal(t, tt.want.expected, actual)
+			}
+			if !tt.mocks.isClosed() {
+				t.Errorf("Should close response body")
+			}
+		})
+	}
+}
+
+func assertErrorMatches(t *testing.T, expected *regexp.Regexp, actual error) {
+	if actual == nil {
+		t.Errorf("Expected error %s but got nil", expected.String())
+	} else if !expected.MatchString(actual.Error()) {
+		t.Errorf("Error message does not match. Expected '%s' but got '%s'", expected.String(), actual.Error())
+	}
+}

--- a/utils/mocks/IoUtil.go
+++ b/utils/mocks/IoUtil.go
@@ -66,6 +66,29 @@ func (_m *IoUtil) Download(URL string, destPath string) error {
 	return r0
 }
 
+// Fetch provides a mock function with given fields: url
+func (_m *IoUtil) Fetch(url string) ([]byte, error) {
+	ret := _m.Called(url)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = rf(url)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(url)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ResolveDestPath provides a mock function with given fields: filePath, destDir
 func (_m *IoUtil) ResolveDestPath(filePath string, destDir string) string {
 	ret := _m.Called(filePath, destDir)

--- a/utils/mocks/MockHttpClient.go
+++ b/utils/mocks/MockHttpClient.go
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2018-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package mocks
+
+import (
+	"bytes"
+	io "io"
+	"net/http"
+	"testing/iotest"
+)
+
+func NewTestHTTPClient(response *http.Response, err error) *http.Client {
+	return &http.Client{
+		Transport: MockRoundTripper{response, err},
+	}
+}
+
+type MockRoundTripper struct {
+	response *http.Response
+	err      error
+}
+
+func (m MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.response, nil
+}
+
+// GenerateResponse generates a mocked *http.Response and returns a function that
+// allows checking if this response's body has been closed.
+func GenerateResponse(body string, statusCode int) (*http.Response, func() bool) {
+	responseBody := &MockResponseBodyImpl{
+		reader:   io.Reader(bytes.NewBufferString(body)),
+		isClosed: new(bool),
+	}
+	response := &http.Response{
+		Body:       responseBody,
+		StatusCode: statusCode,
+	}
+	return response, responseBody.IsClosed
+}
+
+// GenerateErrorResponse generates a mocked *http.Response and returns a function
+// that allows checking if the body of the response has been closed. The body will
+// throw and error when read.
+func GenerateErrorResponse(body string, statusCode int) (*http.Response, func() bool) {
+	responseBody := &MockResponseBodyImpl{
+		reader:   iotest.TimeoutReader(bytes.NewBufferString(body)),
+		isClosed: new(bool),
+	}
+	response := &http.Response{
+		Body:       responseBody,
+		StatusCode: statusCode,
+	}
+	return response, responseBody.IsClosed
+}
+
+// MockResponseBodyImpl is an implementation of MockResponseBody
+type MockResponseBodyImpl struct {
+	reader   io.Reader
+	isClosed *bool
+}
+
+// Read wraps the internal reader's read method.
+func (body MockResponseBodyImpl) Read(p []byte) (n int, err error) {
+	return body.reader.Read(p)
+}
+
+// Close simply sets body.isClosed to true. Useful for checking that response
+// body is closed.
+func (body MockResponseBodyImpl) Close() error {
+	*body.isClosed = true
+	return nil
+}
+
+// IsClosed returns whether or not Close has been called on this body.
+func (body MockResponseBodyImpl) IsClosed() bool {
+	return *body.isClosed
+}


### PR DESCRIPTION
### What does this PR do?
Adds capability for the unified broker to process a list of plugin id, version, and registry fields and download the `meta.yaml`s directly from registry instead of expecting the metas to be present in config.

This PR is broken up into three commits:
1. Add functionality for processing plugin FQNs (fully qualified names) and downloading meta.yamls
2. Modify `ioutil` to enable testing
3. Add tests for ioutil.

### Design decisions
- Support both plugin metas and plugin FQNs (i.e. it is backward compatible)
- Switch between processing metas and FQNs is with argument `--download-metas`
- Default registry can be specified via argument `--registry-address`
  - Default registry is optional but only allowed when all plugin FQNs specify a registry
- Expected config file in FQN case is a json list of objects with fields `id`, `version` and optionally `registry`. This was chosen to mirror `PluginFQN` as used in Che, as the list of `PluginFQN` can be easily serialized into the configmap for the broker.

### Testing directly
This PR also adds a file `brokers/unified/cmd/config-plugin-ids.json`. To test directly, the command
```
cd ./brokers/unified/cmd
go build main.go
./main \
  --disable-push \
  --runtime-id wsId:env:ownerId \
  --registry-address https://che-plugin-registry.openshift.io/plugins \
  --metas ./config-plugin_ids.json \
  --download-metas
```

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1305