### PR TITLE
Fix mistake in usage of append and update Makefile and sample config.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test-local:
 		./main \
 			--disable-push \
 			--runtime-id wsId:env:ownerId \
-			--registry-address https://che-plugin-registry.openshift.io/plugins \
+			--registry-address https://che-plugin-registry.openshift.io \
 			--metas ./config-plugin-ids.json \
 			--download-metas
 

--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -148,7 +148,7 @@ func (b *Broker) ProcessPlugins(metas []model.PluginMeta) error {
 // defaultRegistry is used as the registry for plugins that do not specify their registry.
 // If defaultRegistry is empty, and any plugin does not specify a registry, an error is returned.
 func (b *Broker) getPluginMetas(plugins []model.PluginFQN, defaultRegistry string) ([]model.PluginMeta, error) {
-	metas := make([]model.PluginMeta, len(plugins))
+	metas := make([]model.PluginMeta, 0, len(plugins))
 	for _, plugin := range plugins {
 		log.Printf("Fetching plugin meta.yaml for %s:%s", plugin.ID, plugin.Version)
 		registry, err := getRegistryURL(plugin, defaultRegistry)

--- a/brokers/unified/cmd/config-plugin-ids.json
+++ b/brokers/unified/cmd/config-plugin-ids.json
@@ -10,6 +10,6 @@
   {
     "id": "org.eclipse.che.vscode-redhat.java",
     "version": "0.38.0",
-    "registry": "https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/plugins/"
+    "registry": "https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/"
   }
 ]


### PR DESCRIPTION
### What does this PR do?
I updated PR #40 to use `append` instead of setting indices directly, but forgot to update the length when making the slice, which results in default elements occupying the first half of the array.

Also updates makefile and `config-plugin-ids.json` to not use `/plugins` as part of the registry url, for consistency.

### What issues does this PR fix or reference?
My mistake