### PR TITLE
Fix usage of custom registry

### DIFF
--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -37,7 +37,7 @@ const VscodePluginType = "vs code extension"
 
 // RegistryURLFormat specifies the format string for registry urls
 // when downloading metas
-const RegistryURLFormat = "%s/plugins/%s/%s/meta.yaml"
+const RegistryURLFormat = "%s/%s/%s/meta.yaml"
 
 // Broker is used to process Che plugins
 type Broker struct {
@@ -225,7 +225,7 @@ func getRegistryURL(plugin model.PluginFQN, defaultRegistry string) (string, err
 		if defaultRegistry == "" {
 			return "", fmt.Errorf("plugin '%s' does not specify registry and no default is provided", plugin.ID)
 		}
-		registry = strings.TrimSuffix(defaultRegistry, "/")
+		registry = strings.TrimSuffix(defaultRegistry, "/") + "/plugins"
 	}
 	return registry, nil
 }

--- a/brokers/unified/broker_test.go
+++ b/brokers/unified/broker_test.go
@@ -315,7 +315,7 @@ func TestBroker_processPlugins(t *testing.T) {
 
 func TestBroker_getPluginMetas(t *testing.T) {
 	const defaultRegistry = "defaultRegistry"
-	const RegistryURLFormat = "%s/plugins/%s/%s/meta.yaml"
+	const RegistryURLFormat = "%s/%s/%s/meta.yaml"
 
 	type args struct {
 		fqns            []model.PluginFQN
@@ -365,7 +365,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				errRegexp: nil,
 				fetchURL: fmt.Sprintf(
 					RegistryURLFormat,
-					defaultRegistry,
+					defaultRegistry+"/plugins",
 					pluginFQNWithoutRegistry.ID,
 					pluginFQNWithoutRegistry.Version),
 			},
@@ -441,7 +441,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				errRegexp: nil,
 				fetchURL: fmt.Sprintf(
 					RegistryURLFormat,
-					defaultRegistry,
+					defaultRegistry+"/plugins",
 					pluginFQNWithoutRegistry.ID,
 					pluginFQNWithoutRegistry.Version),
 			},

--- a/brokers/unified/cmd/config-plugin-ids.json
+++ b/brokers/unified/cmd/config-plugin-ids.json
@@ -10,6 +10,6 @@
   {
     "id": "org.eclipse.che.vscode-redhat.java",
     "version": "0.38.0",
-    "registry": "https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/"
+    "registry": "https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/plugins"
   }
 ]


### PR DESCRIPTION
### What does this PR do?
/plugins needs to be added to the default plugin registry only.
This makes broker code compatible with meta downloading that was
previously residing on Che wsmaster side.

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/13208