### PR TITLE
[WIP] Use `localhost` in plugin endpoints by default

### DIFF
--- a/brokers/theia/sidecar.go
+++ b/brokers/theia/sidecar.go
@@ -31,7 +31,9 @@ func GenerateSidecarTooling(image string, pj model.PackageJSON, rand common.Rand
 	endpoint := generateTheiaSidecarEndpoint(rand)
 	setEndpoint(tooling, endpoint)
 	AddExtension(tooling, pj)
-
+  if cfg.UseLocalhostInPluginUrls {
+		tooling.Endpoints = tooling.Endpoints[1:]
+	}
 	return tooling
 }
 

--- a/brokers/vscode/broker.go
+++ b/brokers/vscode/broker.go
@@ -183,6 +183,9 @@ func (b *brokerImpl) injectRemotePlugin(meta model.PluginMeta, image string, arc
 		}
 		theia.AddExtension(tooling, *pj)
 	}
+	if cfg.UseLocalhostInPluginUrls {
+		tooling.Endpoints = tooling.Endpoints[1:]
+	}
 
 	return b.Storage.AddPlugin(&meta, tooling)
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -53,7 +53,8 @@ var (
 	// UseLocalhostInPluginUrls configures the broker to use the `localhost` name
 	// instead of the Kubernetes service name to build Theia or VSCode plugin
 	// endpoint URL
-	UseLocalhostInPluginUrls bool
+	// True by default, at least as long as all the plugin containers are in the same POD
+	UseLocalhostInPluginUrls = true
 
 	// OnlyApplyMetadataActions configures the broker to only apply metadata-related
 	// steps, without copying any file into the `plugins` directory


### PR DESCRIPTION
### What does this PR do?

Since, in the current Che implementation, **all plugin containers are run on the same POD** as the Theia IDE container, let's change the default behavior of the plugin brokers to **use `localhost` as the IP of side-car plugin endpoints**, instead of using the short service name, which, in some cases, cannot be reached.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/11018

### Has this PR been tested ?

Yes, on Minishift Che Addon with the v2 prod-preview plugin registry, the nightly che-server docker image, and the modified unified plugin broker.