### PR TITLE
Add ability to use plugin reference

### DIFF
--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -260,7 +260,7 @@ func sortMetas(metas []model.PluginMeta) (che []model.PluginMeta, vscode []model
 func getRegistryURL(plugin model.PluginFQN, defaultRegistry string) (string, error) {
 	var registry string
 	if plugin.Registry != "" {
-		registry = strings.TrimSuffix(plugin.Registry, "/")
+		registry = strings.TrimSuffix(plugin.Registry, "/") + "/plugins"
 	} else {
 		if defaultRegistry == "" {
 			return "", fmt.Errorf("plugin '%s' does not specify registry and no default is provided", plugin.ID)

--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -260,7 +260,7 @@ func sortMetas(metas []model.PluginMeta) (che []model.PluginMeta, vscode []model
 func getRegistryURL(plugin model.PluginFQN, defaultRegistry string) (string, error) {
 	var registry string
 	if plugin.Registry != "" {
-		registry = strings.TrimSuffix(plugin.Registry, "/") + "/plugins"
+		registry = strings.TrimSuffix(plugin.Registry, "/")
 	} else {
 		if defaultRegistry == "" {
 			return "", fmt.Errorf("plugin '%s' does not specify registry and no default is provided", plugin.ID)

--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -194,14 +194,13 @@ func (b *Broker) GetPluginMeta(plugin model.PluginFQN, defaultRegistry string) (
 	var pluginURL string
 	if plugin.Reference != "" {
 		pluginURL = plugin.Reference
-		log.Printf("Fetching plugin meta.yaml from reference %s", pluginURL)
 	} else {
-		log.Printf("Fetching plugin meta.yaml for %s", plugin.ID)
 		registry, err := getRegistryURL(plugin, defaultRegistry)
 		if err != nil {
 			return nil, err
 		}
 		pluginURL = fmt.Sprintf(RegistryURLFormat, registry, plugin.ID)
+		log.Printf("Fetching plugin meta.yaml from %s", pluginURL)
 	}
 	pluginRaw, err := b.utils.Fetch(pluginURL)
 	if err != nil {

--- a/brokers/unified/broker_test.go
+++ b/brokers/unified/broker_test.go
@@ -1169,6 +1169,21 @@ func TestBroker_getPluginMetas(t *testing.T) {
 			},
 			mocks: successMock,
 		},
+		{
+			name: "Supports custom reference address",
+			args: args{
+				fqns: []model.PluginFQN{
+				{
+					Reference: "http://myregistry.com/plugins/myplugin/meta.yaml",
+				}},
+				defaultRegistry: "",
+			},
+			want: want{
+				errRegexp: nil,
+				fetchURL: "http://myregistry.com/plugins/myplugin/meta.yaml",
+			},
+			mocks: successMock,
+		},
 	}
 
 	for _, tt := range tests {

--- a/brokers/unified/broker_test.go
+++ b/brokers/unified/broker_test.go
@@ -1040,7 +1040,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				errRegexp: nil,
 				fetchURL: fmt.Sprintf(
 					RegistryURLFormat,
-					pluginFQNWithRegistry.Registry,
+					pluginFQNWithRegistry.Registry+"/plugins",
 					pluginFQNWithRegistry.ID),
 			},
 			mocks: successMock,
@@ -1055,7 +1055,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				errRegexp: nil,
 				fetchURL: fmt.Sprintf(
 					RegistryURLFormat,
-					pluginFQNWithRegistry.Registry,
+					pluginFQNWithRegistry.Registry+"/plugins",
 					pluginFQNWithRegistry.ID),
 			},
 			mocks: successMock,
@@ -1082,7 +1082,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				errRegexp: nil,
 				fetchURL: fmt.Sprintf(
 					RegistryURLFormat,
-					strings.TrimSuffix(pluginFQNWithRegistryTrailingSlash.Registry, "/"),
+					strings.TrimSuffix(pluginFQNWithRegistryTrailingSlash.Registry , "/")+"/plugins",
 					pluginFQNWithRegistryTrailingSlash.ID),
 			},
 			mocks: successMock,
@@ -1146,7 +1146,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				errRegexp: nil,
 				fetchURL: fmt.Sprintf(
 					RegistryURLFormat,
-					"http://test-registry.com/v3",
+					"http://test-registry.com/v3/plugins",
 					"test-with-registry/2.0"),
 			},
 			mocks: successMock,
@@ -1165,7 +1165,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				errRegexp: nil,
 				fetchURL: fmt.Sprintf(
 					RegistryURLFormat,
-					"http://test-registry.com/v4",
+					"http://test-registry.com/v4/plugins",
 					"test-with-registry/2.0"),
 			},
 			mocks: successMock,

--- a/brokers/unified/broker_test.go
+++ b/brokers/unified/broker_test.go
@@ -1082,7 +1082,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				errRegexp: nil,
 				fetchURL: fmt.Sprintf(
 					RegistryURLFormat,
-					strings.TrimSuffix(pluginFQNWithRegistryTrailingSlash.Registry , "/")+"/plugins",
+					strings.TrimSuffix(pluginFQNWithRegistryTrailingSlash.Registry, "/")+"/plugins",
 					pluginFQNWithRegistryTrailingSlash.ID),
 			},
 			mocks: successMock,

--- a/brokers/unified/broker_test.go
+++ b/brokers/unified/broker_test.go
@@ -80,7 +80,7 @@ func TestBroker_StartPublishesErrorOnFetchError(t *testing.T) {
 
 	err := m.b.Start([]model.PluginFQN{pluginFQNWithoutRegistry}, "http://defaultRegistry.com")
 
-	expectedMessage := "Failed to download plugin meta: failed to fetch plugin meta.yaml for plugin 'test-no-registry/1.0' from registry 'http://defaultRegistry.com/plugins': Test error"
+	expectedMessage := "Failed to download plugin meta: failed to fetch plugin meta.yaml from URL 'http://defaultRegistry.com/plugins/test-no-registry/1.0/meta.yaml': Test error"
 	assert.EqualError(t, err, expectedMessage)
 	m.cb.AssertCalled(t, "PubFailed", expectedMessage)
 	m.cb.AssertCalled(t, "PubLog", expectedMessage)
@@ -1067,7 +1067,7 @@ func TestBroker_getPluginMetas(t *testing.T) {
 				defaultRegistry: defaultRegistry,
 			},
 			want: want{
-				errRegexp: regexp.MustCompile("failed to fetch plugin meta.yaml for plugin .* from registry .*"),
+				errRegexp: regexp.MustCompile("failed to fetch plugin meta.yaml from URL .*"),
 				fetchURL:  "",
 			},
 			mocks: errorMock,

--- a/model/model.go
+++ b/model/model.go
@@ -93,7 +93,7 @@ type Container struct {
 	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Image        string        `json:"image,omitempty" yaml:"image,omitempty"`
 	Env          []EnvVar      `json:"env" yaml:"env"`
-	Commands     []Command     `json:"commands" yaml:"commands"`
+	Commands     []Command     `json:"editorCommands" yaml:"editorCommands"`
 	Volumes      []Volume      `json:"volumes" yaml:"volumes"`
 	Ports        []ExposedPort `json:"ports" yaml:"ports"`
 	MemoryLimit  string        `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`

--- a/model/model.go
+++ b/model/model.go
@@ -57,8 +57,9 @@ type PluginMetaSpec struct {
 }
 
 type PluginFQN struct {
-	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
-	ID       string `json:"id" yaml:"id"`
+	Registry   string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	ID         string `json:"id" yaml:"id"`
+	Reference  string `json:"reference" yaml:"reference"`
 }
 
 type Endpoint struct {

--- a/model/model.go
+++ b/model/model.go
@@ -93,7 +93,7 @@ type Container struct {
 	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Image        string        `json:"image,omitempty" yaml:"image,omitempty"`
 	Env          []EnvVar      `json:"env" yaml:"env"`
-	Commands     []Command     `json:"editorCommands" yaml:"editorCommands"`
+	Commands     []Command     `json:"commands" yaml:"commands"`
 	Volumes      []Volume      `json:"volumes" yaml:"volumes"`
 	Ports        []ExposedPort `json:"ports" yaml:"ports"`
 	MemoryLimit  string        `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`


### PR DESCRIPTION
### What does this PR do?
This is a PR containing plugin broker part of adding possibility to define chePlugin/cheEditor type components using absolute reference to plugin meta or using custom registryUrl-s.

### What issues does this PR fix or reference?
Fixes Introduce registryUrl field for cheEditor/chePlugin components https://github.com/eclipse/che/issues/13104