### PR TITLE
Make broker preserve extensions for downloaded plugins

### DIFF
--- a/utils/mocks/IoUtil.go
+++ b/utils/mocks/IoUtil.go
@@ -66,6 +66,27 @@ func (_m *IoUtil) Download(URL string, destPath string) error {
 	return r0
 }
 
+// DownloadPreserveFilename provides a mock function with given fields: URL, destPath, defaultFilename
+func (_m *IoUtil) DownloadPreserveFilename(URL string, destPath string, defaultFilename string) (string, error) {
+	ret := _m.Called(URL, destPath, defaultFilename)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string, string) string); ok {
+		r0 = rf(URL, destPath, defaultFilename)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(URL, destPath, defaultFilename)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Fetch provides a mock function with given fields: url
 func (_m *IoUtil) Fetch(url string) ([]byte, error) {
 	ret := _m.Called(url)


### PR DESCRIPTION
### What does this PR do?
- Add function `DownloadPreserveFilename` to `ioutil`
  - Attempts to use Content-Disposition header to determine filename
  - If unable, behaves as previous `Download()` function
  - Necessary for keeping file extensions (e.g. `.theia` for theia
    plugins)
- Make broker add file extension, if available, to copied local plugins
  - This is necessary as files without `.theia` extension are not picked
    up as plugins at workspace runtime
- Remove mentions of VS Code in logging when step can apply to Theia
  plugins as well
- `gofmt` ran automatically on edited files so there are some formatting
  changes.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13349