### PR TITLE
Make the brokers usable as a library again

### DIFF
--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -47,7 +47,7 @@ type Broker struct {
 	vscodeBroker common.BrokerImpl
 }
 
-// NewBroker creates Che broker instance
+// NewBrokerWithParams creates Che broker instance with parameters
 func NewBrokerWithParams(
 	commonBroker common.Broker,
 	ioUtil utils.IoUtil,
@@ -55,14 +55,14 @@ func NewBrokerWithParams(
 	rand common.Random,
 	httpClient *http.Client,
 	localhostSidecar bool) *Broker {
-		vscodeBroker := vscode.NewBrokerWithParams(commonBroker, ioUtil, storage, rand, httpClient, localhostSidecar)
-		return &Broker{
-			Broker:       commonBroker,
-			Storage:      storage,
-			utils:        ioUtil,
-			vscodeBroker: vscodeBroker,
-		}
+	vscodeBroker := vscode.NewBrokerWithParams(commonBroker, ioUtil, storage, rand, httpClient, localhostSidecar)
+	return &Broker{
+		Broker:       commonBroker,
+		Storage:      storage,
+		utils:        ioUtil,
+		vscodeBroker: vscodeBroker,
 	}
+}
 
 // NewBroker creates Che broker instance
 func NewBroker(localhostSidecar bool) *Broker {


### PR DESCRIPTION
### What does this PR do?

This PR slightly refactors the code in order to enable other components to use brokers as a GO library.
This is useful for the new Che Workspace Operator that embeds brokering, and was broken by the last `che-plugin-broker` changes.

### What issues does this PR fix or reference?

No issue.