### PR TITLE
Updating codeowners for Che 7 endgame code reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @amisevsk
+* @amisevsk @l0rd @rhopp @nickboldt @vparfonov


### PR DESCRIPTION
Adding @l0rd @rhopp and @nickboldt as global code reviewers as required by eclipse/che#13637