### PR TITLE
Print number of downloaded extensions for a plugin

### DIFF
--- a/brokers/unified/vscode/broker.go
+++ b/brokers/unified/vscode/broker.go
@@ -159,7 +159,7 @@ func (b *brokerImpl) injectRemotePlugin(plugin model.ChePlugin, archivesPaths []
 			if err != nil {
 				return err
 			}
-			
+
 			pluginArchivePath := filepath.Join(pluginFolderPath, b.generatePluginArchiveName(plugin, archive))
 			b.PrintDebug("Copying VS Code extension '%s' from '%s' to '%s'", plugin.ID, archive, pluginArchivePath)
 			err = b.ioUtil.CopyFile(archive, pluginArchivePath)
@@ -190,10 +190,11 @@ func convertMetaToPlugin(meta model.PluginMeta) model.ChePlugin {
 
 func (b *brokerImpl) downloadArchives(URLs []string, meta model.PluginMeta, workDir string) ([]string, error) {
 	paths := make([]string, 0)
-	for _, URL := range URLs {
+	archivesNumber := len(URLs)
+	for i, URL := range URLs {
 		archivePath := b.ioUtil.ResolveDestPathFromURL(URL, workDir)
 		b.PrintDebug("Downloading VS Code extension archive '%s' for plugin '%s' to '%s'", URL, meta.ID, archivePath)
-		b.PrintInfo("Downloading VS Code extension for plugin '%s'", meta.ID)
+		b.PrintInfo("Downloading VS Code extension '%d' of '%d' for plugin '%s'", i, archivesNumber, meta.ID)
 		archivePath, err := b.downloadArchive(URL, archivePath)
 		paths = append(paths, archivePath)
 		if err != nil {

--- a/brokers/unified/vscode/broker_test.go
+++ b/brokers/unified/vscode/broker_test.go
@@ -13,13 +13,13 @@
 package vscode
 
 import (
-	"strings"
 	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tests "github.com/eclipse/che-plugin-broker/brokers/test"
@@ -569,7 +569,7 @@ func expectedPluginsWithSingleRemotePluginWithSeveralExtensions(usedLocalhost bo
 				Value: "4242",
 			},
 		}
-		expectedPlugin.Endpoints = []model.Endpoint {
+		expectedPlugin.Endpoints = []model.Endpoint{
 			model.Endpoint{
 				Name:       "randomString1234567890",
 				Public:     false,
@@ -577,7 +577,7 @@ func expectedPluginsWithSingleRemotePluginWithSeveralExtensions(usedLocalhost bo
 			},
 		}
 		expectedPlugin.WorkspaceEnv = append(expectedPlugin.WorkspaceEnv, model.EnvVar{
-			Name:  "THEIA_PLUGIN_REMOTE_ENDPOINT_" + strings.ReplaceAll(pluginPublisher + "_" + pluginName + "_" + pluginVersion, " ", "_"),
+			Name:  "THEIA_PLUGIN_REMOTE_ENDPOINT_" + strings.ReplaceAll(pluginPublisher+"_"+pluginName+"_"+pluginVersion, " ", "_"),
 			Value: "ws://randomString1234567890:4242",
 		})
 	}
@@ -607,7 +607,7 @@ func setUpSuccessfulCase(workDir string, meta model.PluginMeta, m *mocks) {
 	m.u.On("CopyFile", mock.AnythingOfType("string"), pluginPath).Return(nil)
 	m.cb.On("PrintDebug", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
 	m.cb.On("PrintDebug", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
-	m.cb.On("PrintInfo", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
+	m.cb.On("PrintInfo", mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int"), mock.AnythingOfType("string"))
 	m.u.On("Download", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return("test005528325", nil)
 	m.u.On("TempDir", "", "vscode-extension-broker").Return(workDir, nil)
 	m.randMock.On("IntFromRange", 4000, 10000).Return(4242)
@@ -618,7 +618,7 @@ func setUpSuccessfulCase(workDir string, meta model.PluginMeta, m *mocks) {
 func setUpDownloadFailureCase(workDir string, m *mocks) {
 	m.cb.On("PrintDebug", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
 	m.cb.On("PrintDebug", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
-	m.cb.On("PrintInfo", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
+	m.cb.On("PrintInfo", mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int"), mock.AnythingOfType("string"))
 	m.u.On("Download", vsixBrokenURL, mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return("", errors.New("Failed to download plugin")).Once()
 	m.u.On("TempDir", "", "vscode-extension-broker").Return(workDir, nil).Once()
 	m.randMock.On("IntFromRange", 4000, 10000).Return(4242).Once()


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

### What does this PR do?
Improves the log message while downloading extensions for a plugin. It will print the number of extension is being downloaded and the total number of extensions for a plugin.

```
Downloading VS Code extension 1 of 1 for plugin `redhat/vscode-xml/0.7.0`
Downloading VS Code extension 1 of 2 for plugin `redhat/java/0.38.0`
Downloading VS Code extension 2 of 2 for plugin `redhat/java/0.38.0`
```

This PR was done in context of testing Eclipse Che with a real project (https://github.com/eclipse/che/issues/13679)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13388