### PR TITLE
Add the self-signed certificate to the plugin broker HTTP client

### DIFF
--- a/common/connect.go
+++ b/common/connect.go
@@ -13,6 +13,7 @@
 package common
 
 import (
+	"net/http"
 	"log"
 
 	"github.com/eclipse/che-go-jsonrpc"
@@ -55,6 +56,10 @@ func ConfigureCertPool(customCertificateFilePath string) {
 
 	// Trust the augmented cert pool in our client
 	jsonrpcws.DefaultDialer.TLSClientConfig = &tls.Config{
+		RootCAs: rootCAs,
+	}
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
 		RootCAs: rootCAs,
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the Openshift router self-signed certificate to the Go http client in the plugin broker when needed. So, this fixes the bug that was occuring in the plugin broker when running Che with TLS, self-signed certificates enabled, and embedded registries (deployed behind Openshift routes).

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/14087