### PR TITLE
Support relative paths

### DIFF
--- a/brokers/unified/vscode/sidecar.go
+++ b/brokers/unified/vscode/sidecar.go
@@ -19,7 +19,7 @@ import (
 	"github.com/eclipse/che-plugin-broker/model"
 )
 
-// AddPluginRequirements adds to ChePlugin configuration needed to run remote Theia plugins in the provided ChePlugin.
+// AddPluginRunnerRequirements adds to ChePlugin configuration needed to run remote Theia plugins in the provided ChePlugin.
 // Method adds needed ports, endpoints, volumes, environment variables.
 // ChePlugin with one container is supported only.
 func AddPluginRunnerRequirements(plugin model.ChePlugin, rand common.Random, useLocalhost bool) model.ChePlugin {


### PR DESCRIPTION
### What does this PR do?
Adds support for relative paths in plugin meta.yaml extensions. This allows `meta.yaml`s in the plugin registry to specify e.g. 
```yaml
spec:
  extensions:
    - relative:extension/path/to/artifact
```
which will be resolved to `${PLUGIN_REGISTRY_URL}/path/to/artifact` during plugin broker execution.

I chose the format `relative:extension/` to mirror the vscode marketplace support already in place, with `vscode:extension/` although I'm open to suggestions.

### Testing this PR
A dockerimage built from this PR is available at `amisevsk/che-unified-plugin-broker:relative-paths`. I've also deployed a patched plugin registry with most `.vsix` and `.theia` artifacts cached and metas updated appropriately, available as `amisevsk/che-plugin-registry:cached-artifacts`.

```
CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE=amisevsk/che-unified-plugin-broker:relative-paths
CHE_WORKSPACE_PLUGIN__REGISTRY__URL=http://che-plugin-registry-eclipse-che.devtools-dev.ext.devshift.net/v3
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14163