### PR TITLE
Start remote binary using env and appling ephemeral volume

### DIFF
--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -143,6 +143,10 @@ func (b *Broker) ProcessPlugins(metas []model.PluginMeta) error {
 		}
 	}
 
+	// if plugins, err := b.Storage.Plugins(); err != nil {
+	// 	InjectRemoteRuntime(plugins)
+	// }
+
 	return nil
 }
 
@@ -334,5 +338,6 @@ func ConvertMetaToPlugin(meta model.PluginMeta) model.ChePlugin {
 		InitContainers: meta.Spec.InitContainers,
 		Endpoints:      meta.Spec.Endpoints,
 		WorkspaceEnv:   meta.Spec.WorkspaceEnv,
+		Type:           meta.Type,
 	}
 }

--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -95,6 +95,10 @@ func (b *Broker) Start(pluginFQNs []model.PluginFQN, defaultRegistry string) err
 		return err
 	}
 
+	if plugins, err := b.Storage.Plugins(); err == nil {
+		InjectRemoteRuntime(plugins)
+	}
+
 	result, err := b.serializeTooling()
 	if err != nil {
 		b.PubFailed(err.Error())
@@ -142,10 +146,6 @@ func (b *Broker) ProcessPlugins(metas []model.PluginMeta) error {
 			return err
 		}
 	}
-
-	// if plugins, err := b.Storage.Plugins(); err != nil {
-	// 	InjectRemoteRuntime(plugins)
-	// }
 
 	return nil
 }

--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -31,11 +31,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const ChePluginType = "che plugin"
-const EditorPluginType = "che editor"
-const TheiaPluginType = "theia plugin"
-const VscodePluginType = "vs code extension"
-
 // RegistryURLFormat specifies the format string for registry urls
 // when downloading metas
 const RegistryURLFormat = "%s/%s/meta.yaml"
@@ -232,18 +227,18 @@ func ValidateMeta(meta model.PluginMeta) error {
 	}
 
 	switch strings.ToLower(meta.Type) {
-	case ChePluginType:
+	case model.ChePluginType:
 		fallthrough
-	case EditorPluginType:
+	case model.EditorPluginType:
 		if len(meta.Spec.Extensions) != 0 {
 			return fmt.Errorf("Plugin '%s' is invalid. Field 'spec.extensions' is not allowed in plugin of type '%s'", meta.ID, meta.Type)
 		}
 		if len(meta.Spec.Containers) == 0 {
 			return fmt.Errorf("Plugin '%s' is invalid. Field 'spec.containers' must not be empty", meta.ID)
 		}
-	case TheiaPluginType:
+	case model.TheiaPluginType:
 		fallthrough
-	case VscodePluginType:
+	case model.VscodePluginType:
 		if len(meta.Spec.Extensions) == 0 {
 			return fmt.Errorf("Plugin '%s' is invalid. Field 'spec.extensions' must not be empty", meta.ID)
 		}
@@ -271,13 +266,13 @@ func sortMetas(metas []model.PluginMeta) (che []model.PluginMeta, vscode []model
 	cheBrokerMetas := make([]model.PluginMeta, 0)
 	for _, meta := range metas {
 		switch strings.ToLower(meta.Type) {
-		case ChePluginType:
+		case model.ChePluginType:
 			fallthrough
-		case EditorPluginType:
+		case model.EditorPluginType:
 			cheBrokerMetas = append(cheBrokerMetas, meta)
-		case TheiaPluginType:
+		case model.TheiaPluginType:
 			fallthrough
-		case VscodePluginType:
+		case model.VscodePluginType:
 			vscodeMetas = append(vscodeMetas, meta)
 		case "":
 			return nil, nil, fmt.Errorf("Type field is missing in meta information of plugin '%s'", meta.ID)

--- a/brokers/unified/broker.go
+++ b/brokers/unified/broker.go
@@ -95,8 +95,15 @@ func (b *Broker) Start(pluginFQNs []model.PluginFQN, defaultRegistry string) err
 		return err
 	}
 
-	if plugins, err := b.Storage.Plugins(); err == nil {
-		InjectRemoteRuntime(plugins)
+	plugins, err := b.Storage.Plugins()
+	if err != nil {
+		b.PubFailed(err.Error())
+		b.PubLog(err.Error())
+	}
+
+	if err := InjectRemoteRuntime(plugins); err != nil {
+		b.PubFailed(err.Error())
+		b.PubLog(err.Error())
 	}
 
 	result, err := b.serializeTooling()

--- a/brokers/unified/broker_test.go
+++ b/brokers/unified/broker_test.go
@@ -272,7 +272,7 @@ func TestBroker_processPlugins(t *testing.T) {
 				},
 			},
 			want: want{
-				commonPlugins: []model.ChePlugin{createChePlugin("id2"), createChePlugin("id6")},
+				commonPlugins: []model.ChePlugin{createChePlugin("id2", TestChePluginType), createChePlugin("id6", TestChePluginType)},
 				vscodeMetas:   []model.PluginMeta{createVSCodeMeta("id1"), createVSCodeMeta("id4"), createTheiaMeta("id3"), createTheiaMeta("id5")},
 			},
 		},
@@ -283,7 +283,7 @@ func TestBroker_processPlugins(t *testing.T) {
 				metas: []model.PluginMeta{createChePluginMeta("id1"), createCheEditorMeta("id2")},
 			},
 			want: want{
-				commonPlugins: []model.ChePlugin{createChePlugin("id1"), createChePlugin("id2")},
+				commonPlugins: []model.ChePlugin{createChePlugin("id1", TestChePluginType), createChePlugin("id2", TestEditorPluginType)},
 			},
 		},
 		{
@@ -297,7 +297,7 @@ func TestBroker_processPlugins(t *testing.T) {
 						Name:        "name1",
 						Version:     "v0.13",
 						ID:          "id1",
-						Type:        ChePluginType,
+						Type:        model.ChePluginType,
 						Title:       "test title",
 						DisplayName: "test display name",
 						Description: "test description",
@@ -339,7 +339,7 @@ func TestBroker_processPlugins(t *testing.T) {
 						Name:        "name2",
 						Version:     "v0",
 						ID:          "id2",
-						Type:        EditorPluginType,
+						Type:        model.EditorPluginType,
 						Title:       "test title",
 						DisplayName: "test display name",
 						Description: "test description",
@@ -374,6 +374,7 @@ func TestBroker_processPlugins(t *testing.T) {
 						Name:      "name1",
 						Version:   "v0.13",
 						ID:        "id1",
+						Type:      model.ChePluginType,
 						Endpoints: []model.Endpoint{
 							{
 								Name:       "end1",
@@ -408,6 +409,7 @@ func TestBroker_processPlugins(t *testing.T) {
 						Name:      "name2",
 						Version:   "v0",
 						ID:        "id2",
+						Type:      model.EditorPluginType,
 						Endpoints: []model.Endpoint{
 							{
 								Name:       "end2",
@@ -441,7 +443,7 @@ func TestBroker_processPlugins(t *testing.T) {
 						Name:        "name1",
 						Version:     "v0.13",
 						ID:          "id1",
-						Type:        ChePluginType,
+						Type:        model.ChePluginType,
 						Title:       "test title",
 						DisplayName: "test display name",
 						Description: "test description",
@@ -486,6 +488,7 @@ func TestBroker_processPlugins(t *testing.T) {
 						Name:      "name1",
 						Version:   "v0.13",
 						ID:        "id1",
+						Type:        model.ChePluginType,
 						Endpoints: []model.Endpoint{
 							{
 								Name:       "end1",
@@ -686,6 +689,7 @@ func TestBroker_processPlugins(t *testing.T) {
 				commonPlugins: []model.ChePlugin{
 					{
 						ID: "id11",
+						Type: "che plugin",
 						Containers: []model.Container{
 							{
 								Image: defaultImage,
@@ -694,6 +698,7 @@ func TestBroker_processPlugins(t *testing.T) {
 					},
 					{
 						ID: "id12",
+						Type:       "Che Plugin",
 						Containers: []model.Container{
 							{
 								Image: defaultImage,
@@ -702,6 +707,7 @@ func TestBroker_processPlugins(t *testing.T) {
 					},
 					{
 						ID: "id13",
+						Type: "cHE plugIN",
 						Containers: []model.Container{
 							{
 								Image: defaultImage,
@@ -752,7 +758,7 @@ func TestBroker_processPlugins(t *testing.T) {
 			args: args{
 				metas: []model.PluginMeta{
 					{
-						Type:       ChePluginType,
+						Type:       model.ChePluginType,
 						ID:         "test id",
 						Version:    "test version",
 						Publisher:  "test publisher",
@@ -1541,9 +1547,10 @@ func createMetaWithExtension(ID string, extensions ...string) model.PluginMeta {
 	}
 }
 
-func createChePlugin(ID string) model.ChePlugin {
+func createChePlugin(ID string, pluginType string) model.ChePlugin {
 	return model.ChePlugin{
 		ID: ID,
+		Type: pluginType,
 		Containers: []model.Container{
 			{
 				Image: defaultImage,

--- a/brokers/unified/broker_test.go
+++ b/brokers/unified/broker_test.go
@@ -488,7 +488,7 @@ func TestBroker_processPlugins(t *testing.T) {
 						Name:      "name1",
 						Version:   "v0.13",
 						ID:        "id1",
-						Type:        model.ChePluginType,
+						Type:      model.ChePluginType,
 						Endpoints: []model.Endpoint{
 							{
 								Name:       "end1",
@@ -688,7 +688,7 @@ func TestBroker_processPlugins(t *testing.T) {
 				},
 				commonPlugins: []model.ChePlugin{
 					{
-						ID: "id11",
+						ID:   "id11",
 						Type: "che plugin",
 						Containers: []model.Container{
 							{
@@ -697,8 +697,8 @@ func TestBroker_processPlugins(t *testing.T) {
 						},
 					},
 					{
-						ID: "id12",
-						Type:       "Che Plugin",
+						ID:   "id12",
+						Type: "Che Plugin",
 						Containers: []model.Container{
 							{
 								Image: defaultImage,
@@ -706,7 +706,7 @@ func TestBroker_processPlugins(t *testing.T) {
 						},
 					},
 					{
-						ID: "id13",
+						ID:   "id13",
 						Type: "cHE plugIN",
 						Containers: []model.Container{
 							{
@@ -1549,7 +1549,7 @@ func createMetaWithExtension(ID string, extensions ...string) model.PluginMeta {
 
 func createChePlugin(ID string, pluginType string) model.ChePlugin {
 	return model.ChePlugin{
-		ID: ID,
+		ID:   ID,
 		Type: pluginType,
 		Containers: []model.Container{
 			{

--- a/brokers/unified/remote_runtime_injector.go
+++ b/brokers/unified/remote_runtime_injector.go
@@ -28,7 +28,7 @@ const (
 	RemoteEndPointVolumePath = "/remote-endpoint"
 
 	RemoteEndPontExecutableEnvVar = "PLUGIN_REMOTE_ENDPOINT"
-	RemoteEndPointExecutable      = "entrypoint.sh"
+	RemoteEndPointExecutable      = "plugin-remote-endpoint"
 	RemoteEndPointExecPath        = RemoteEndPointVolumePath + "/" + RemoteEndPointExecutable
 )
 

--- a/brokers/unified/remote_runtime_injector.go
+++ b/brokers/unified/remote_runtime_injector.go
@@ -108,7 +108,7 @@ func findEnv(envName string, envVars []model.EnvVar) (*model.EnvVar, error) {
 	for _, envVar := range envVars {
 		if envVar.Name == envName {
 			result = &envVar
-			continue
+			break
 		}
 	}
 	if result == nil {

--- a/brokers/unified/remote_runtime_injector.go
+++ b/brokers/unified/remote_runtime_injector.go
@@ -29,7 +29,7 @@ const (
 )
 
 type RemotePluginInjection struct {
-	Volume model.Volume
+	Volume  model.Volume
 	Env     model.EnvVar
 	Command []string
 	Args    []string
@@ -84,7 +84,7 @@ func getRuntimeInjection(editorPlugin *model.ChePlugin) (*RemotePluginInjection,
 	}
 
 	return &RemotePluginInjection{
-		Volume: *volume,
+		Volume:  *volume,
 		Env:     *runtimeBinaryPathEnv,
 		Command: []string{runtimeBinaryPathEnv.Value},
 	}, nil
@@ -128,7 +128,4 @@ func inject(plugin *model.ChePlugin, injection *RemotePluginInjection) {
 
 	container.Env = append(container.Env, injection.Env)
 	container.Volumes = append(container.Volumes, injection.Volume)
-	if len(container.Command) == 0 && len(container.Args) == 0 {
-		container.Command = injection.Command
-	}
 }

--- a/brokers/unified/remote_runtime_injector.go
+++ b/brokers/unified/remote_runtime_injector.go
@@ -29,7 +29,7 @@ const (
 )
 
 type RemotePluginInjection struct {
-	Volumes model.Volume
+	Volume model.Volume
 	Env     model.EnvVar
 	Command []string
 	Args    []string
@@ -84,7 +84,7 @@ func getRuntimeInjection(editorPlugin *model.ChePlugin) (*RemotePluginInjection,
 	}
 
 	return &RemotePluginInjection{
-		Volumes: *volume,
+		Volume: *volume,
 		Env:     *runtimeBinaryPathEnv,
 		Command: []string{runtimeBinaryPathEnv.Value},
 	}, nil
@@ -127,7 +127,7 @@ func inject(plugin *model.ChePlugin, injection *RemotePluginInjection) {
 	container := &plugin.Containers[0]
 
 	container.Env = append(container.Env, injection.Env)
-	container.Volumes = append(container.Volumes, injection.Volumes)
+	container.Volumes = append(container.Volumes, injection.Volume)
 	if len(container.Command) == 0 && len(container.Args) == 0 {
 		container.Command = injection.Command
 	}

--- a/brokers/unified/remote_runtime_injector.go
+++ b/brokers/unified/remote_runtime_injector.go
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package unified
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+const (
+	DefaultEditorName = "che-theia"
+
+	InjectorContainerName = "remote-runtime-injector"
+
+	RemoteEndPointVolume     = "remote-endpoint"
+	RemoteEndPointVolumePath = "/remote-endpoint"
+
+	RemoteEndPontExecutableEnvVar = "PLUGIN_REMOTE_ENDPOINT"
+	RemoteEndPointExecutable      = "entrypoint.sh"
+	RemoteEndPointExecPath        = RemoteEndPointVolumePath + "/" + RemoteEndPointExecutable
+)
+
+type RemotePluginInjection struct {
+	Volumes model.Volume
+	Env     model.EnvVar
+	Command []string
+	Args    []string
+}
+
+func InjectRemoteRuntime(plugins []model.ChePlugin) {
+	_, err := findEditorPlugin(plugins)
+	if err != nil {
+		return
+	}
+
+	// injection, err := getInjection(editorPlugin)
+	// if err != nil {
+	// 	return
+	// }
+
+	injection := &RemotePluginInjection{
+		Volumes: model.Volume{
+			Name:      RemoteEndPointVolume,
+			MountPath: RemoteEndPointVolumePath,
+			Ephemeral: true,
+		},
+		Env: model.EnvVar{
+			Name:  RemoteEndPontExecutableEnvVar,
+			Value: RemoteEndPointExecPath,
+		},
+		Command: []string{RemoteEndPointExecPath},
+	}
+	for _, plugin := range plugins {
+		inject(&plugin, injection)
+	}
+}
+
+func findEditorPlugin(plugins []model.ChePlugin) (*model.ChePlugin, error) {
+	for _, plugin := range plugins {
+		if plugin.Type == model.EditorPluginType {
+			return &plugin, nil
+		}
+	}
+	return nil, errors.New("Unable to find editor plugin")
+}
+
+// func getInjection(editorPlugin *model.ChePlugin) (RemotePluginInjection, error) {
+// var injectionContainer model.Container
+// for _, initContainer := range editorPlugin.InitContainers {
+// 	if initContainer.Name == InjectorContainerName {
+// 		injectionContainer = initContainer
+// 		continue
+// 	}
+// }
+// injectionContainer.Env
+// }
+
+func inject(plugin *model.ChePlugin, injection *RemotePluginInjection) {
+	pluginType := strings.ToLower(plugin.Type)
+
+	if pluginType != model.ChePluginType && pluginType != model.VscodePluginType {
+		return
+	}
+	// sidecar container has one and only one container.
+	container := &plugin.Containers[0]
+
+	container.Env = append(container.Env, injection.Env)
+	container.Volumes = append(container.Volumes, injection.Volumes)
+	if len(container.Command) == 0 && len(container.Args) == 0 {
+		container.Command = injection.Command
+	}
+}

--- a/brokers/unified/remote_runtime_injector_test.go
+++ b/brokers/unified/remote_runtime_injector_test.go
@@ -174,7 +174,6 @@ func exectedVsCodePluginWithRuntimeInjection() *model.ChePlugin {
 						Ephemeral: true,
 					},
 				},
-				Command: []string{ExecutablePathTest},
 			},
 		},
 	}

--- a/brokers/unified/remote_runtime_injector_test.go
+++ b/brokers/unified/remote_runtime_injector_test.go
@@ -19,6 +19,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	ExecutablePathTest = "/some-path"
+	VolumeNameTest     = "some-volume"
+	VolumePathTest     = "/some-volume"
+)
+
 func TestShouldNotInjectRemotePluginRuntimeForChePluginType(t *testing.T) {
 	editorPlugin := createEditorPluginWithRuntimeInjection()
 	vscodePlugin := createPlugin(model.ChePluginType)
@@ -69,11 +75,20 @@ func createEditorPluginWithRuntimeInjection() *model.ChePlugin {
 		{
 			Image: "eclipse/che-theia-runtime-binary",
 			Name:  InjectorContainerName,
-			Env:   []model.EnvVar{},
+			Env: []model.EnvVar{
+				{
+					Name:  RemoteEndPontExecutableEnvVar,
+					Value: ExecutablePathTest,
+				},
+				{
+					Name:  VolumeNameEnvVar,
+					Value: VolumeNameTest,
+				},
+			},
 			Volumes: []model.Volume{
 				{
-					Name:      RemoteEndPointVolume,
-					MountPath: RemoteEndPointVolumePath,
+					Name:      VolumeNameTest,
+					MountPath: VolumePathTest,
 					Ephemeral: true,
 				},
 			},
@@ -145,7 +160,7 @@ func exectedVsCodePluginWithRuntimeInjection() *model.ChePlugin {
 					},
 					{
 						Name:  RemoteEndPontExecutableEnvVar,
-						Value: RemoteEndPointExecPath,
+						Value: ExecutablePathTest,
 					},
 				},
 				Volumes: []model.Volume{
@@ -154,12 +169,12 @@ func exectedVsCodePluginWithRuntimeInjection() *model.ChePlugin {
 						MountPath: "/projects",
 					},
 					{
-						Name:      RemoteEndPointVolume,
-						MountPath: RemoteEndPointVolumePath,
+						Name:      VolumeNameTest,
+						MountPath: VolumePathTest,
 						Ephemeral: true,
 					},
 				},
-				Command: []string{RemoteEndPointExecPath},
+				Command: []string{ExecutablePathTest},
 			},
 		},
 	}

--- a/brokers/unified/remote_runtime_injector_test.go
+++ b/brokers/unified/remote_runtime_injector_test.go
@@ -77,7 +77,7 @@ func createEditorPluginWithRuntimeInjection() *model.ChePlugin {
 			Name:  InjectorContainerName,
 			Env: []model.EnvVar{
 				{
-					Name:  RemoteEndPontExecutableEnvVar,
+					Name:  RemoteEndPointExecutableEnvVar,
 					Value: ExecutablePathTest,
 				},
 				{
@@ -101,7 +101,7 @@ func createEditorPlugin() *model.ChePlugin {
 	return &model.ChePlugin{
 		ID:        "some-id-1",
 		Version:   "latest",
-		Name:      DefaultEditorName,
+		Name:      CheTheiaEditorName,
 		Type:      model.EditorPluginType,
 		Publisher: "eclipse",
 		Containers: []model.Container{
@@ -159,7 +159,7 @@ func exectedVsCodePluginWithRuntimeInjection() *model.ChePlugin {
 						Value: "some-value",
 					},
 					{
-						Name:  RemoteEndPontExecutableEnvVar,
+						Name:  RemoteEndPointExecutableEnvVar,
 						Value: ExecutablePathTest,
 					},
 				},

--- a/brokers/unified/vscode/broker.go
+++ b/brokers/unified/vscode/broker.go
@@ -129,7 +129,7 @@ func (b *brokerImpl) ProcessPlugin(meta model.PluginMeta) error {
 		err = b.injectLocalPlugin(plugin, archivesPaths)
 		return err
 	}
-	return b.injectRemotePlugin(plugin, archivesPaths, workDir, meta.Type)
+	return b.injectRemotePlugin(plugin, archivesPaths, workDir)
 }
 
 func (b *brokerImpl) injectLocalPlugin(plugin model.ChePlugin, archivesPaths []string) error {
@@ -149,8 +149,8 @@ func getPluginUniqueName(plugin model.ChePlugin) string {
 	return re.ReplaceAllString(plugin.Publisher+"_"+plugin.Name+"_"+plugin.Version, `_`)
 }
 
-func (b *brokerImpl) injectRemotePlugin(plugin model.ChePlugin, archivesPaths []string, workDir string, pluginType string) error {
-	plugin = AddPluginRunnerRequirements(plugin, pluginType, b.rand, b.localhostSidecar)
+func (b *brokerImpl) injectRemotePlugin(plugin model.ChePlugin, archivesPaths []string, workDir string) error {
+	plugin = AddPluginRunnerRequirements(plugin, b.rand, b.localhostSidecar)
 	for _, archive := range archivesPaths {
 		if !cfg.OnlyApplyMetadataActions {
 			pluginName := getPluginUniqueName(plugin)
@@ -186,6 +186,7 @@ func convertMetaToPlugin(meta model.PluginMeta) model.ChePlugin {
 		InitContainers: meta.Spec.InitContainers,
 		Endpoints:      meta.Spec.Endpoints,
 		WorkspaceEnv:   meta.Spec.WorkspaceEnv,
+		Type:           meta.Type,
 	}
 }
 

--- a/brokers/unified/vscode/broker.go
+++ b/brokers/unified/vscode/broker.go
@@ -129,7 +129,7 @@ func (b *brokerImpl) ProcessPlugin(meta model.PluginMeta) error {
 		err = b.injectLocalPlugin(plugin, archivesPaths)
 		return err
 	}
-	return b.injectRemotePlugin(plugin, archivesPaths, workDir)
+	return b.injectRemotePlugin(plugin, archivesPaths, workDir, meta.Type)
 }
 
 func (b *brokerImpl) injectLocalPlugin(plugin model.ChePlugin, archivesPaths []string) error {
@@ -149,8 +149,8 @@ func getPluginUniqueName(plugin model.ChePlugin) string {
 	return re.ReplaceAllString(plugin.Publisher+"_"+plugin.Name+"_"+plugin.Version, `_`)
 }
 
-func (b *brokerImpl) injectRemotePlugin(plugin model.ChePlugin, archivesPaths []string, workDir string) error {
-	plugin = AddPluginRunnerRequirements(plugin, b.rand, b.localhostSidecar)
+func (b *brokerImpl) injectRemotePlugin(plugin model.ChePlugin, archivesPaths []string, workDir string, pluginType string) error {
+	plugin = AddPluginRunnerRequirements(plugin, pluginType, b.rand, b.localhostSidecar)
 	for _, archive := range archivesPaths {
 		if !cfg.OnlyApplyMetadataActions {
 			pluginName := getPluginUniqueName(plugin)

--- a/brokers/unified/vscode/broker_test.go
+++ b/brokers/unified/vscode/broker_test.go
@@ -250,7 +250,7 @@ func TestBroker_processPlugin(t *testing.T) {
 				},
 			},
 			useLocalhost: false,
-			want:         expectedPluginsWithSingleRemotePluginWithInitContainer(false),
+			want:         expectedPluginsWithSingleRemotePluginWithInitContainer(false, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin with initContainers and ephemeral volume",
@@ -290,7 +290,7 @@ func TestBroker_processPlugin(t *testing.T) {
 				},
 			},
 			useLocalhost: false,
-			want:         expectedPluginsWithSingleRemotePluginWithInitContainer(true),
+			want:         expectedPluginsWithSingleRemotePluginWithInitContainer(true, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin when extension points to .theia archive, using a generated host name",
@@ -313,7 +313,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: false,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				false),
+				false, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin when extension points to .theia archive, using localhost as the host name",
@@ -336,7 +336,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: true,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				true),
+				true, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of local plugin with extensions field with several extensions",
@@ -413,7 +413,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: false,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				false),
+				false, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin with extensions field with several extensions, using localhost as the host name",
@@ -436,7 +436,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: true,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				true),
+				true, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin with extensions field with several extensions, using a generated the host name",
@@ -461,7 +461,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: false,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				false),
+				false, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin with extensions field with several extensions, using localhost as the host name",
@@ -486,7 +486,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: true,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				true),
+				true, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin with extensions field with mixed extensions and archives URLs, using a generated host name",
@@ -511,7 +511,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: false,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				false),
+				false, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin with extensions field with mixed extensions and archives URLs, using localhost as the host name",
@@ -536,7 +536,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: true,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				true),
+				true, vscodePluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin with extensions field with mixed extensions and archives URLs when plugin type is Theia, using a generated host name",
@@ -561,7 +561,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: false,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				false),
+				false, theiaPluginType),
 		},
 		{
 			name: "Successful brokering of remote plugin with extensions field with mixed extensions and archives URLs when plugin type is Theia, using localhost as the host name",
@@ -586,7 +586,7 @@ func TestBroker_processPlugin(t *testing.T) {
 			},
 			useLocalhost: true,
 			want: expectedPluginsWithSingleRemotePluginWithSeveralExtensions(
-				true),
+				true, theiaPluginType),
 		},
 	}
 	for _, tt := range cases {
@@ -618,12 +618,13 @@ func TestBroker_processPlugin(t *testing.T) {
 	}
 }
 
-func expectedPluginsWithSingleRemotePluginWithInitContainer(ephemeral bool) []model.ChePlugin {
+func expectedPluginsWithSingleRemotePluginWithInitContainer(ephemeral bool, pluginType string) []model.ChePlugin {
 	expectedPlugin := model.ChePlugin{
 		ID:        pluginID,
 		Version:   pluginVersion,
 		Publisher: pluginPublisher,
 		Name:      pluginName,
+		Type: pluginType,
 		Containers: []model.Container{
 			{
 				Image: image,
@@ -688,12 +689,13 @@ func expectedPluginsWithSingleRemotePluginWithInitContainer(ephemeral bool) []mo
 	}
 }
 
-func expectedPluginsWithSingleRemotePluginWithSeveralExtensions(usedLocalhost bool) []model.ChePlugin {
+func expectedPluginsWithSingleRemotePluginWithSeveralExtensions(usedLocalhost bool, pluginType string) []model.ChePlugin {
 	expectedPlugin := model.ChePlugin{
 		ID:        pluginID,
 		Version:   pluginVersion,
 		Publisher: pluginPublisher,
 		Name:      pluginName,
+		Type: pluginType,
 		Containers: []model.Container{
 			{
 				Image: image,

--- a/brokers/unified/vscode/broker_test.go
+++ b/brokers/unified/vscode/broker_test.go
@@ -624,7 +624,7 @@ func expectedPluginsWithSingleRemotePluginWithInitContainer(ephemeral bool, plug
 		Version:   pluginVersion,
 		Publisher: pluginPublisher,
 		Name:      pluginName,
-		Type: pluginType,
+		Type:      pluginType,
 		Containers: []model.Container{
 			{
 				Image: image,
@@ -695,7 +695,7 @@ func expectedPluginsWithSingleRemotePluginWithSeveralExtensions(usedLocalhost bo
 		Version:   pluginVersion,
 		Publisher: pluginPublisher,
 		Name:      pluginName,
-		Type: pluginType,
+		Type:      pluginType,
 		Containers: []model.Container{
 			{
 				Image: image,

--- a/brokers/unified/vscode/sidecar.go
+++ b/brokers/unified/vscode/sidecar.go
@@ -24,7 +24,7 @@ import (
 // ChePlugin with one container is supported only.
 func AddPluginRunnerRequirements(plugin model.ChePlugin, rand common.Random, useLocalhost bool) model.ChePlugin {
 	// TODO limitation is one and only sidecar
-	container := plugin.Containers[0]
+	container := &plugin.Containers[0]
 	container.Volumes = append(container.Volumes, model.Volume{
 		Name:      "plugins",
 		MountPath: "/plugins",
@@ -46,7 +46,6 @@ func AddPluginRunnerRequirements(plugin model.ChePlugin, rand common.Random, use
 		Name:  "THEIA_PLUGINS",
 		Value: "local-dir:///plugins/sidecars/" + getPluginUniqueName(plugin),
 	})
-	plugin.Containers[0] = container
 
 	return plugin
 }

--- a/brokers/unified/vscode/sidecar.go
+++ b/brokers/unified/vscode/sidecar.go
@@ -14,45 +14,21 @@ package vscode
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/eclipse/che-plugin-broker/common"
 	"github.com/eclipse/che-plugin-broker/model"
 )
 
-const (
-	RemoteEndPointVolume     = "remote-endpoint"
-	RemoteEndPointVolumePath = "/remote-endpoint"
-
-	RemoteEndPontExecutableEnvVar = "PLUGIN_REMOTE_ENDPOINT"
-	RemoteEndPointExecutable      = "entrypoint.sh"
-	RemoteEndPointExecPath        = RemoteEndPointVolumePath + "/" + RemoteEndPointExecutable
-)
-
 // AddPluginRunnerRequirements adds to ChePlugin configuration needed to run remote Theia plugins in the provided ChePlugin.
 // Method adds needed ports, endpoints, volumes, environment variables.
 // ChePlugin with one container is supported only.
-func AddPluginRunnerRequirements(plugin model.ChePlugin, pluginType string, rand common.Random, useLocalhost bool) model.ChePlugin {
+func AddPluginRunnerRequirements(plugin model.ChePlugin, rand common.Random, useLocalhost bool) model.ChePlugin {
 	// TODO limitation is one and only sidecar
 	container := plugin.Containers[0]
-	container.Volumes = append(
-		container.Volumes,
-		model.Volume{
-			Name:      "plugins",
-			MountPath: "/plugins",
-		},
-		model.Volume{
-			Name:      RemoteEndPointVolume,
-			MountPath: RemoteEndPointVolumePath,
-			Ephemeral: true,
-		},
-	)
-
-	pluginType = strings.ToLower(pluginType)
-	if (pluginType == model.ChePluginType || pluginType == model.VscodePluginType) &&
-		len(container.Command) == 0 && len(container.Args) == 0 {
-		container.Command = []string{RemoteEndPointExecPath}
-	}
+	container.Volumes = append(container.Volumes, model.Volume{
+		Name:      "plugins",
+		MountPath: "/plugins",
+	})
 
 	container.MountSources = true
 	if !useLocalhost {
@@ -66,17 +42,10 @@ func AddPluginRunnerRequirements(plugin model.ChePlugin, pluginType string, rand
 			Value: strconv.Itoa(port),
 		})
 	}
-	container.Env = append(container.Env,
-		model.EnvVar{
-			Name:  "THEIA_PLUGINS",
-			Value: "local-dir:///plugins/sidecars/" + getPluginUniqueName(plugin),
-		},
-		model.EnvVar{
-			Name:  RemoteEndPontExecutableEnvVar,
-			Value: RemoteEndPointExecPath,
-		},
-	)
-
+	container.Env = append(container.Env, model.EnvVar{
+		Name:  "THEIA_PLUGINS",
+		Value: "local-dir:///plugins/sidecars/" + getPluginUniqueName(plugin),
+	})
 	plugin.Containers[0] = container
 
 	return plugin

--- a/model/model.go
+++ b/model/model.go
@@ -113,4 +113,5 @@ type ChePlugin struct {
 	Containers     []Container `json:"containers" yaml:"containers"`
 	InitContainers []Container `json:"initContainers" yaml:"initContainers"`
 	WorkspaceEnv   []EnvVar    `json:"workspaceEnv" yaml:"workspaceEnv"`
+	Type           string      `json:"type" yaml:"type"`
 }

--- a/model/plugin_types.go
+++ b/model/plugin_types.go
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package model
+
+const (
+	ChePluginType    = "che plugin"
+	EditorPluginType = "che editor"
+	TheiaPluginType  = "theia plugin"
+	VscodePluginType = "vs code extension"
+)


### PR DESCRIPTION
### What does this PR do?
At this pr I changed a  bit model: applied Type field to the model.ChePlugin

Inject remote endpoint binary using env variable with remote binary path and volume where is binary  located.
For this purpose we are using init container from che-theia editor-plugin:

```yaml
initContainers:
  - name: remote-runtime-injector
    image: aandrienko/che-theia-endpoint-runtime-binary:next
    volumes:
      - mountPath: "/remote-endpoint"
        name: remote-endpoint
        ephemeral: true
    env:
      - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
        value: /remote-endpoint/plugin-remote-endpoint
      - name: REMOTE_ENDPOINT_VOLUME_NAME
        value: remote-endpoint
```

Plugin broker should find this init container by name `remote-runtime-injector` and only for che-theia editor plugin. Then plugin-broker should analize env variables and volume from init container.

`REMOTE_ENDPOINT_VOLUME_NAME` env we are using to find one volume which should be shared with other sidecar containers. In this volume init container on start should copy remote binary

`PLUGIN_REMOTE_ENDPOINT_EXECUTABLE` env will be shared with all sidecar containers.

To start remote binary in the sidecar container, plugin writer should define in the sidecar dockerfile ENTRYPOINT:

```Dockerfile
FROM some-image 
....
ENTRYPOINT ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE} 
```

Or apply starting remote binary in the entrypoint.sh script, if plugin image uses such one.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13387