### PR TITLE
Improve how already-downloaded plugin extensions are handled.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 
 # Ignore binaries with these names but not folders with the same names
-init-plugin-broker
-unified-plugin-broker
+plugin-artifacts-broker
+plugin-metadata-broker
 **/cmd/cmd
 main
 

--- a/brokers/artifacts/broker.go
+++ b/brokers/artifacts/broker.go
@@ -14,15 +14,12 @@ package artifacts
 
 import (
 	"fmt"
-	"path/filepath"
 
 	jsonrpc "github.com/eclipse/che-go-jsonrpc"
 	"github.com/eclipse/che-plugin-broker/common"
 	"github.com/eclipse/che-plugin-broker/model"
 	"github.com/eclipse/che-plugin-broker/utils"
 )
-
-const errorNoExtFieldsTemplate = "Field 'extensions' is not found in the description of the plugin '%s'"
 
 // Broker is used to process Che plugins
 type Broker struct {
@@ -58,122 +55,55 @@ func (b *Broker) Start(pluginFQNs []model.PluginFQN, defaultRegistry string) err
 	b.PubStarted()
 	b.PrintInfo("Starting plugin artifacts broker")
 
-	b.cleanupPluginsDirectory()
 	pluginMetas, err := utils.GetPluginMetas(pluginFQNs, defaultRegistry, b.ioUtils)
 	if err != nil {
 		return b.fail(fmt.Errorf("Failed to download plugin meta: %s", err))
 	}
-	b.PrintInfo("Downloading plugin extensions")
 
 	err = utils.ResolveRelativeExtensionPaths(pluginMetas, defaultRegistry)
 	if err != nil {
 		return b.fail(err)
 	}
 
-	for _, meta := range pluginMetas {
-		err = b.ProcessPlugin(meta)
+	requestedPlugins := convertMetasToPlugins(pluginMetas)
+
+	toInstall := b.syncWithPluginsDir(requestedPlugins)
+
+	for _, plugin := range toInstall {
+		err = b.ProcessPlugin(&plugin)
 		if err != nil {
 			return b.fail(err)
 		}
 	}
 
+	err = b.writeInstalledPlugins(toInstall)
+	if err != nil {
+		b.PrintInfo("WARN: Failed to log installed plugins: %s", err)
+	}
+
 	b.PrintInfo("All plugin artifacts have been successfully downloaded")
 	b.PubDone("")
-
 	return nil
 }
 
-func (b *Broker) cleanupPluginsDirectory() {
-	b.PrintInfo("Cleaning /plugins dir")
-	files, err := b.ioUtils.GetFilesByGlob(filepath.Join("/plugins", "*"))
-	if err != nil {
-		// Send log about clearing failure but proceed.
-		// We might want to change this behavior later
-		b.PrintInfo("WARN: failed to clear /plugins directory. Error: %s", err)
-		return
-	}
+func convertMetasToPlugins(metas []model.PluginMeta) []model.CachedPlugin {
+	plugins := make([]model.CachedPlugin, 0)
 
-	for _, file := range files {
-		err = b.ioUtils.RemoveAll(file)
-		if err != nil {
-			b.PrintInfo("WARN: failed to remove '%s'. Error: %s", file, err)
+	for _, meta := range metas {
+		if !utils.IsTheiaOrVscodePlugin(meta) {
+			continue
 		}
-	}
-}
-
-// ProcessPlugin processes metas of different plugin types and passes metas of each particular type
-// to the appropriate plugin broker
-func (b *Broker) ProcessPlugin(meta model.PluginMeta) error {
-	if !utils.IsTheiaOrVscodePlugin(meta) {
-		return nil
-	}
-
-	URLs, err := getUrls(meta)
-	if err != nil {
-		return err
-	}
-
-	workDir, err := b.ioUtils.TempDir("", "vscode-extension-broker")
-	if err != nil {
-		return err
-	}
-
-	archivesPaths, err := b.downloadArchives(URLs, meta, workDir)
-	if err != nil {
-		return err
-	}
-
-	err = b.injectPlugin(meta, archivesPaths)
-	return err
-}
-
-func (b *Broker) downloadArchives(URLs []string, meta model.PluginMeta, workDir string) ([]string, error) {
-	paths := make([]string, 0)
-	for i, URL := range URLs {
-		archivePath := b.ioUtils.ResolveDestPathFromURL(URL, workDir)
-		b.PrintDebug("Downloading VS Code extension archive '%s' for plugin '%s' to '%s'", URL, meta.ID, archivePath)
-		b.PrintInfo("Downloading VS Code extension %d/%d for plugin '%s'", i+1, len(URLs), meta.ID)
-		archivePath, err := b.ioUtils.Download(URL, archivePath, true)
-		paths = append(paths, archivePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to download plugin from %s: %s", URL, err)
-		}
-	}
-	return paths, nil
-}
-
-func (b *Broker) injectPlugin(meta model.PluginMeta, archivesPaths []string) error {
-	for _, path := range archivesPaths {
-		pluginPath := "/plugins"
+		plugin := model.CachedPlugin{}
+		plugin.ID = meta.ID
 		if len(meta.Spec.Containers) > 0 {
-			// Plugin is remote
-			pluginUniqueName := utils.GetPluginUniqueName(meta)
-			pluginPath = filepath.Join(pluginPath, "sidecars", pluginUniqueName)
-			err := b.ioUtils.MkDir(pluginPath)
-			if err != nil {
-				return err
-			}
+			plugin.IsRemote = true
 		}
-		pluginArchiveName := b.generatePluginArchiveName(meta, path)
-		pluginArchivePath := filepath.Join(pluginPath, pluginArchiveName)
-		err := b.ioUtils.CopyFile(path, pluginArchivePath)
-		if err != nil {
-			return err
+		plugin.CachedExtensions = make(map[string]string)
+		for _, ext := range meta.Spec.Extensions {
+			plugin.CachedExtensions[ext] = ""
 		}
+		plugins = append(plugins, plugin)
 	}
-	return nil
-}
 
-func (b *Broker) generatePluginArchiveName(plugin model.PluginMeta, archivePath string) string {
-	archiveName := filepath.Base(archivePath)
-	return fmt.Sprintf("%s.%s.%s.%s.%s", plugin.Publisher, plugin.Name, plugin.Version, b.rand.String(10), archiveName)
-}
-
-func getUrls(meta model.PluginMeta) ([]string, error) {
-	URLs := make([]string, 0)
-	if len(meta.Spec.Extensions) == 0 {
-		return nil, fmt.Errorf(errorNoExtFieldsTemplate, meta.ID)
-	}
-	URLs = append(URLs, meta.Spec.Extensions...)
-	return URLs, nil
+	return plugins
 }

--- a/brokers/artifacts/broker_test.go
+++ b/brokers/artifacts/broker_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	commonMock "github.com/eclipse/che-plugin-broker/common/mocks"
@@ -45,6 +44,7 @@ func initMocks() *mocks {
 	// It doesn't seem to be possible to mock variadic arguments
 	commonBroker.On("PrintInfo", mock.AnythingOfType("string"), mock.Anything)
 	commonBroker.On("PrintInfo", mock.AnythingOfType("string"), mock.Anything, mock.Anything, mock.Anything)
+	commonBroker.On("PrintInfoBuffer", mock.Anything)
 	commonBroker.On("PrintDebug", mock.AnythingOfType("string"))
 	commonBroker.On("PrintDebug", mock.AnythingOfType("string"), mock.Anything, mock.Anything, mock.Anything)
 	commonBroker.On("PubFailed", mock.AnythingOfType("string"))
@@ -64,49 +64,6 @@ func initMocks() *mocks {
 			rand:    rand,
 		},
 	}
-}
-
-func TestStartCleansPluginDirectoryOnStart(t *testing.T) {
-	m := initMocks()
-	m.ioUtils.On("GetFilesByGlob", mock.AnythingOfType("string")).Return([]string{"testPath1", "testPath2"}, nil)
-	m.ioUtils.On("RemoveAll", "testPath1").Return(nil)
-	m.ioUtils.On("RemoveAll", "testPath2").Return(nil)
-
-	err := m.broker.Start([]model.PluginFQN{}, "default.io")
-	assert.Nil(t, err)
-	m.ioUtils.AssertExpectations(t)
-	m.commonBroker.AssertCalled(t, "CloseConsumers")
-}
-
-func TestStartLogsErrorOnFailureToGlob(t *testing.T) {
-	expectedError := errors.New("failed")
-
-	m := initMocks()
-	m.ioUtils.On("GetFilesByGlob", mock.AnythingOfType("string")).Return(nil, expectedError)
-	m.commonBroker.On("PrintInfo", "WARN: failed to clear /plugins directory. Error: %s", expectedError)
-
-	err := m.broker.Start([]model.PluginFQN{}, "default.io")
-	assert.Nil(t, err)
-	m.ioUtils.AssertExpectations(t)
-	m.commonBroker.AssertCalled(t, "PrintInfo", "WARN: failed to clear /plugins directory. Error: %s", expectedError)
-	m.commonBroker.AssertCalled(t, "CloseConsumers")
-}
-
-func TestStartLogsErrorOnFailureToRemoveAll(t *testing.T) {
-	expectedError := errors.New("failed")
-
-	m := initMocks()
-	m.ioUtils.On("GetFilesByGlob", mock.AnythingOfType("string")).Return([]string{"testPath1", "testPath2"}, nil)
-	m.ioUtils.On("RemoveAll", "testPath1").Return(expectedError)
-	m.ioUtils.On("RemoveAll", "testPath2").Return(nil)
-	m.commonBroker.On("PrintInfo", "WARN: failed to remove '%s'. Error: %s", "testPath1", expectedError)
-
-	err := m.broker.Start([]model.PluginFQN{}, "default.io")
-	assert.Nil(t, err)
-
-	m.ioUtils.AssertExpectations(t)
-	m.commonBroker.AssertCalled(t, "PrintInfo", "WARN: failed to remove '%s'. Error: %s", "testPath1", expectedError)
-	m.commonBroker.AssertCalled(t, "CloseConsumers")
 }
 
 func TestStartFailsIfFetchFails(t *testing.T) {
@@ -146,139 +103,87 @@ func TestFailureResolvingRelativeExtensionPaths(t *testing.T) {
 }
 
 func TestStartPropagatesErrorOnPluginProcessing(t *testing.T) {
-	pluginMeta, _ := loadPluginMetaFromFile(t, "vscode-java-0.50.0.yaml")
-	pluginMeta.Spec.Extensions = []string{}
-	var pluginMetaBytes []byte
-	pluginMetaBytes, yamlErr := yaml.Marshal(pluginMeta)
-	if yamlErr != nil {
-		t.Errorf("Failed to marshal yaml")
-	}
+	_, pluginMetaBytes := loadPluginMetaFromFile(t, "vscode-java-0.50.0.yaml")
 	defaultRegistry := ""
+
 	pluginFQNs := []model.PluginFQN{
 		generatePluginFQN("testRegistry", "testID", ""),
 	}
-	expectedErrorString := fmt.Sprintf("Field 'extensions' is not found in the description of the plugin '%s'", "testID")
+	expectedErrorString := "test error"
 
 	m := initMocks()
+	m.ioUtils.On("ReadFile", mock.AnythingOfType("string")).Return(nil, fmt.Errorf("Disabled for tests"))
+	m.ioUtils.On("WriteFile", mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	m.ioUtils.On("RemoveFile", mock.AnythingOfType("string")).Return(nil)
 	m.ioUtils.On("GetFilesByGlob", mock.AnythingOfType("string")).Return([]string{}, nil)
 	m.ioUtils.On("Fetch", mock.AnythingOfType("string")).Return(pluginMetaBytes, nil)
+	m.ioUtils.On("TempDir", mock.Anything, mock.Anything).Return("", fmt.Errorf(expectedErrorString))
 
 	err := m.broker.Start(pluginFQNs, defaultRegistry)
 	assert.EqualError(t, err, expectedErrorString)
 	m.commonBroker.AssertCalled(t, "PubFailed", expectedErrorString)
 	m.commonBroker.AssertCalled(t, "PubLog", expectedErrorString)
 	m.commonBroker.AssertCalled(t, "CloseConsumers")
+	// Make sure cached plugins file is not written
+	m.ioUtils.AssertNotCalled(t, "WriteFile", mock.Anything, mock.Anything)
 }
 
 func TestStartSuccessfulFlow(t *testing.T) {
 	m := initMocks()
+	m.ioUtils.On("ReadFile", mock.AnythingOfType("string")).Return(nil, fmt.Errorf("Disabled for tests"))
+	m.ioUtils.On("WriteFile", mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	m.ioUtils.On("RemoveFile", mock.AnythingOfType("string")).Return(nil)
+	m.ioUtils.On("GetFilesByGlob", mock.AnythingOfType("string")).Return([]string{}, nil)
+	m.ioUtils.On("Fetch", "testRegistry/plugins/testID/meta.yaml").Return([]byte{}, nil)
 
 	defaultRegistry := "default.io"
 	pluginFQNs := []model.PluginFQN{
 		generatePluginFQN("testRegistry", "testID", ""),
 	}
-	m.ioUtils.On("GetFilesByGlob", mock.AnythingOfType("string")).Return([]string{}, nil)
-	m.ioUtils.On("Fetch", "testRegistry/plugins/testID/meta.yaml").Return([]byte{}, nil)
 
 	err := m.broker.Start(pluginFQNs, defaultRegistry)
 	assert.Nil(t, err)
 
 	m.commonBroker.AssertCalled(t, "PubStarted")
-	m.commonBroker.AssertCalled(t, "PrintInfo", "Downloading plugin extensions")
+	m.commonBroker.AssertCalled(t, "PrintInfo", "Starting plugin artifacts broker")
 	m.commonBroker.AssertCalled(t, "PrintInfo", "All plugin artifacts have been successfully downloaded")
 	m.commonBroker.AssertCalled(t, "PubDone", "")
 	m.commonBroker.AssertCalled(t, "CloseConsumers")
 }
 
-func TestProcessPluginDoesNothingForChePlugin(t *testing.T) {
+func TestConvertMetasToPluginsExcludesChePlugins(t *testing.T) {
 	meta, _ := loadPluginMetaFromFile(t, "machine-exec-7.4.0.yaml")
-	m := initMocks()
-	err := m.broker.ProcessPlugin(meta)
-	assert.Nil(t, err)
+	metas := []model.PluginMeta{meta}
+	output := convertMetasToPlugins(metas)
+	assert.Equal(t, 0, len(output))
 }
 
-func TestProcessPluginReturnsErrorWhenNoExtensions(t *testing.T) {
-	meta, _ := loadPluginMetaFromFile(t, "vscode-java-0.50.0.yaml")
-	meta.Spec.Extensions = []string{}
-	meta.ID = "testId"
-
-	expectedError := fmt.Sprintf(errorNoExtFieldsTemplate, "testId")
-
-	m := initMocks()
-	err := m.broker.ProcessPlugin(meta)
-	assert.EqualError(t, err, expectedError)
+func TestConvertMetasToPluginsConvertsRemoteVSCodePlugin(t *testing.T) {
+	meta, _ := loadPluginMetaFromFile(t, "remote-vscode-ext.yaml")
+	metas := []model.PluginMeta{meta}
+	output := convertMetasToPlugins(metas)
+	assert.Equal(t, 1, len(output))
+	plugin := output[0]
+	assert.Equal(t, meta.ID, plugin.ID)
+	assert.True(t, plugin.IsRemote)
+	assert.Equal(t, len(meta.Spec.Extensions), len(plugin.CachedExtensions))
+	for _, ext := range meta.Spec.Extensions {
+		assert.Contains(t, plugin.CachedExtensions, ext)
+	}
 }
 
-func TestProcessPluginReturnsErrorWhenFailureToCreateTempDir(t *testing.T) {
-	meta, _ := loadPluginMetaFromFile(t, "vscode-java-0.50.0.yaml")
-	expectedError := errors.New("test error")
-
-	m := initMocks()
-	m.ioUtils.On("TempDir", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("", expectedError)
-
-	err := m.broker.ProcessPlugin(meta)
-	assert.EqualError(t, err, expectedError.Error())
-}
-
-func TestProcessPluginReturnsErrorWhenFailureDownloadArchives(t *testing.T) {
-	meta, _ := loadPluginMetaFromFile(t, "vscode-java-0.50.0.yaml")
-	expectedError := errors.New("test error")
-	expectedErrorRegexp := regexp.MustCompile("failed to download plugin from .*: test error")
-
-	m := initMocks()
-	m.ioUtils.On("TempDir", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("testDir", nil)
-	m.ioUtils.On("ResolveDestPathFromURL", mock.AnythingOfType("string"), "testDir").Return("testDestDir")
-	m.ioUtils.On("Download", mock.AnythingOfType("string"), "testDestDir", true).Return("", expectedError)
-
-	err := m.broker.ProcessPlugin(meta)
-	assert.Regexp(t, expectedErrorRegexp, err.Error())
-}
-
-func TestProcessPluginReturnsErrorWhenCantMakeDir(t *testing.T) {
-	meta, _ := loadPluginMetaFromFile(t, "vscode-java-0.50.0.yaml")
-	expectedError := errors.New("test error")
-
-	m := initMocks()
-	m.ioUtils.On("TempDir", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("testDir", nil)
-	m.ioUtils.On("ResolveDestPathFromURL", mock.AnythingOfType("string"), "testDir").Return("testDestDir")
-	m.ioUtils.On("Download", mock.AnythingOfType("string"), "testDestDir", true).Return("testDownloadDir", nil)
-	m.ioUtils.On("MkDir", mock.AnythingOfType("string")).Return(expectedError)
-
-	err := m.broker.ProcessPlugin(meta)
-	assert.EqualError(t, err, expectedError.Error())
-}
-
-func TestProcessPluginReturnsErrorWhenCantCopyFile(t *testing.T) {
-	meta, _ := loadPluginMetaFromFile(t, "vscode-java-0.50.0.yaml")
-	expectedError := errors.New("test error")
-
-	m := initMocks()
-	m.ioUtils.On("TempDir", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("testDir", nil)
-	m.ioUtils.On("ResolveDestPathFromURL", mock.AnythingOfType("string"), "testDir").Return("testDestDir")
-	m.ioUtils.On("Download", mock.AnythingOfType("string"), "testDestDir", true).Return("testDownloadDir", nil)
-	m.ioUtils.On("MkDir", mock.AnythingOfType("string")).Return(nil)
-	m.rand.On("String", 10).Return("xxxxx")
-	m.ioUtils.On("CopyFile", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(expectedError)
-
-	err := m.broker.ProcessPlugin(meta)
-	assert.EqualError(t, err, expectedError.Error())
-}
-
-func TestProcessPluginProcessesAllExtensions(t *testing.T) {
-	meta, _ := loadPluginMetaFromFile(t, "vscode-java-0.50.0.yaml")
-
-	m := initMocks()
-	m.ioUtils.On("TempDir", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("testDir", nil)
-	m.ioUtils.On("ResolveDestPathFromURL", mock.AnythingOfType("string"), "testDir").Return("testDestDir")
-	m.ioUtils.On("Download", mock.AnythingOfType("string"), "testDestDir", true).Return("testDownloadDir", nil)
-	m.ioUtils.On("MkDir", mock.AnythingOfType("string")).Return(nil)
-	m.rand.On("String", 10).Return("xxxxx")
-	m.ioUtils.On("CopyFile", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
-
-	err := m.broker.ProcessPlugin(meta)
-	assert.Nil(t, err)
-	m.ioUtils.AssertNumberOfCalls(t, "Download", 2)
-	m.ioUtils.AssertNumberOfCalls(t, "CopyFile", 2)
+func TestConvertMetasToPluginsConvertsNonRemoteVSCodePlugin(t *testing.T) {
+	meta, _ := loadPluginMetaFromFile(t, "non-remote-vscode-ext.yaml")
+	metas := []model.PluginMeta{meta}
+	output := convertMetasToPlugins(metas)
+	assert.Equal(t, 1, len(output))
+	plugin := output[0]
+	assert.Equal(t, meta.ID, plugin.ID)
+	assert.False(t, plugin.IsRemote)
+	assert.Equal(t, len(meta.Spec.Extensions), len(plugin.CachedExtensions))
+	for _, ext := range meta.Spec.Extensions {
+		assert.Contains(t, plugin.CachedExtensions, ext)
+	}
 }
 
 func loadPluginMetaFromFile(t *testing.T, filename string) (model.PluginMeta, []byte) {

--- a/brokers/artifacts/cache.go
+++ b/brokers/artifacts/cache.go
@@ -1,0 +1,176 @@
+//
+// Copyright (c) 2018-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package artifacts
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+const installedPluginsJSONFile = "/plugins/installed.json"
+const installedPluginsJSONVersion = "1.0"
+
+// syncWithPluginsDir takes a list of requested plugins and resolves it against what is currently
+// installed, returning a list of InstalledPlugins that need to be downloaded. Note that
+// returned list may be partially filled, if e.g. only one of two extensions in a plugin
+// need to be updated.
+// Plugins that are out of date will be deleted from the local filesystem, and any extensions
+// that are not included in the current requested plugins will be removed.
+func (b *Broker) syncWithPluginsDir(requested []model.CachedPlugin) (toInstall []model.CachedPlugin) {
+	installed, err := b.readInstalledPlugins()
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// If file does not exist, printing error is unnecessary.
+			b.PrintDebug("Error encountered during reading installed plugins: %s", err)
+			b.PrintInfo("Failed to get installed plugins")
+		}
+		// Unable to read -- default to wiping everything and installing all plugins
+		b.resetPluginsDirectory()
+		return requested
+	}
+	toInstall = b.preparePluginsToInstall(requested, installed)
+	return toInstall
+}
+
+// preparePluginsToInstall will prepare the /plugins directory for installation and return a list of (partially-filled)
+// plugins to be installed. Any plugins that are currently installed but not requested in the workspace will
+// be removed from the filesystem.
+func (b *Broker) preparePluginsToInstall(requested, installed []model.CachedPlugin) (toInstall []model.CachedPlugin) {
+	toInstall = requested
+	for _, plugin := range installed {
+		match := findPlugin(plugin, requested)
+		if match == nil {
+			// Plugin has been uninstalled since last start
+			b.PrintInfo("Uninstalling plugin: %s", plugin.ID)
+			if err := b.removePlugin(plugin); err != nil {
+				b.PrintInfo("WARN: failed to remove plugin artifacts: %s", err)
+			}
+			continue
+		}
+		for ext, path := range plugin.CachedExtensions {
+			if _, ok := match.CachedExtensions[ext]; ok {
+				// Extension is already downloaded, fill path in struct to avoid downloading later.
+				match.CachedExtensions[ext] = path
+			} else {
+				// Downloaded plugin is not used in current workspace and must be removed.
+				err := b.ioUtils.RemoveFile(path)
+				if err != nil {
+					b.PrintInfo("WARN: Failed to clean up plugin at %s: %s", path, err)
+				}
+			}
+		}
+	}
+	return toInstall
+}
+
+func (b *Broker) readInstalledPlugins() ([]model.CachedPlugin, error) {
+	bytes, err := b.ioUtils.ReadFile(installedPluginsJSONFile)
+	if err != nil {
+		return nil, err
+	}
+	err = b.ioUtils.RemoveFile(installedPluginsJSONFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var pluginsJSON model.InstalledPluginJSON
+	err = json.Unmarshal(bytes, &pluginsJSON)
+	if err != nil {
+		return nil, err
+	}
+	if pluginsJSON.Version != installedPluginsJSONVersion {
+		b.PrintInfo("Installed plugins cache is incompatible with current version of plugin broker. All plugins will be redownloaded.")
+		return nil, fmt.Errorf("Installed plugins list is from previous version of broker")
+	}
+
+	err = b.checkInstalledPluginsFilePaths(pluginsJSON.Plugins)
+	if err != nil {
+		return nil, err
+	}
+	return pluginsJSON.Plugins, nil
+}
+
+func (b *Broker) checkInstalledPluginsFilePaths(installed []model.CachedPlugin) error {
+	for _, plugin := range installed {
+		for _, extension := range plugin.CachedExtensions {
+			if !b.ioUtils.FileExists(extension) {
+				return fmt.Errorf("unable to locate cached extension for plugin %s", plugin.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func (b *Broker) writeInstalledPlugins(cached []model.CachedPlugin) error {
+	b.PrintInfo("Saving log of installed plugins")
+	cachedJSON := model.InstalledPluginJSON{
+		Version: installedPluginsJSONVersion,
+		Plugins: cached,
+	}
+	bytes, err := json.MarshalIndent(cachedJSON, "", "  ")
+	if err != nil {
+		return err
+	}
+	err = b.ioUtils.WriteFile(installedPluginsJSONFile, bytes)
+	return err
+}
+
+func (b *Broker) removePlugin(plugin model.CachedPlugin) error {
+	if plugin.IsRemote {
+		// remote plugins have a subdirectory in /plugins/sidecars
+		for _, extPath := range plugin.CachedExtensions {
+			dir := path.Dir(extPath)
+			return b.ioUtils.RemoveAll(dir)
+		}
+	} else {
+		// non-remote plugins are stored in /plugins as single files
+		for _, extPath := range plugin.CachedExtensions {
+			return b.ioUtils.RemoveFile(extPath)
+		}
+	}
+	return nil
+}
+
+func (b *Broker) resetPluginsDirectory() {
+	b.PrintInfo("Cleaning /plugins dir")
+	files, err := b.ioUtils.GetFilesByGlob(filepath.Join("/plugins", "*"))
+	if err != nil {
+		// Send log about clearing failure but proceed.
+		// We might want to change this behavior later
+		b.PrintInfo("WARN: failed to clear /plugins directory. Error: %s", err)
+		return
+	}
+
+	for _, file := range files {
+		err = b.ioUtils.RemoveAll(file)
+		if err != nil {
+			b.PrintInfo("WARN: failed to remove '%s'. Error: %s", file, err)
+		}
+	}
+}
+
+func findPlugin(query model.CachedPlugin, plugins []model.CachedPlugin) *model.CachedPlugin {
+	for _, plugin := range plugins {
+		// Note we need to ensure IsRemote matches, since remote plugins are handled
+		// differently
+		if plugin.ID == query.ID && plugin.IsRemote == query.IsRemote {
+			return &plugin
+		}
+	}
+	return nil
+}

--- a/brokers/artifacts/cache_test.go
+++ b/brokers/artifacts/cache_test.go
@@ -1,0 +1,448 @@
+//
+// Copyright (c) 2018-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package artifacts
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/eclipse/che-plugin-broker/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSyncWithPluginsDirPrintsErrorWhenUnableToRead(t *testing.T) {
+	m := initMocks()
+	m.ioUtils.On("ReadFile", mock.Anything).Return(nil, fmt.Errorf("test error"))
+	m.ioUtils.On("GetFilesByGlob", mock.Anything).Return([]string{"test_file"}, nil)
+	m.ioUtils.On("RemoveAll", mock.Anything).Return(nil)
+
+	m.broker.syncWithPluginsDir([]model.CachedPlugin{})
+
+	m.commonBroker.AssertCalled(t, "PrintInfo", "Failed to get installed plugins")
+	m.ioUtils.AssertCalled(t, "RemoveAll", "test_file")
+}
+
+func TestSyncWithPluginsDirDoesNotPrintOutputWhenFileNotExist(t *testing.T) {
+	m := initMocks()
+	m.ioUtils.On("ReadFile", mock.Anything).Return(nil, os.ErrNotExist)
+	m.ioUtils.On("GetFilesByGlob", mock.Anything).Return([]string{"test_file"}, nil)
+	m.ioUtils.On("RemoveAll", mock.Anything).Return(nil)
+
+	m.broker.syncWithPluginsDir([]model.CachedPlugin{})
+
+	m.commonBroker.AssertNotCalled(t, "PrintInfo", "Failed to get installed plugins")
+	m.ioUtils.AssertCalled(t, "RemoveAll", "test_file")
+}
+
+func TestPreparePluginsToInstall(t *testing.T) {
+	requested := []model.CachedPlugin{
+		generateCachedPlugin(t, "1-newPlugin", false, "1-newUrl", ""),
+		generateCachedPlugin(t, "2-existingPlugin", true, "2-existingUrl", "", "2-newUrl", ""),
+	}
+	installed := []model.CachedPlugin{
+		generateCachedPlugin(t, "3-removedPlugin", true, "3-removedUrl", "/3-dir/3-removedPath"),
+		generateCachedPlugin(t, "2-existingPlugin", true, "2-existingUrl", "/2-dir/2-existingPath", "2-oldUrl", "/2-dir/2-removedPath"),
+	}
+	expected := []model.CachedPlugin{
+		generateCachedPlugin(t, "1-newPlugin", false, "1-newUrl", ""),
+		generateCachedPlugin(t, "2-existingPlugin", true, "2-existingUrl", "/2-dir/2-existingPath", "2-newUrl", ""),
+	}
+
+	m := initMocks()
+	m.ioUtils.On("RemoveAll", "/3-dir").Return(nil)
+	m.ioUtils.On("RemoveFile", "/2-dir/2-removedPath").Return(nil)
+
+	output := m.broker.preparePluginsToInstall(requested, installed)
+
+	assert.NotNil(t, output)
+	assert.ElementsMatch(t, output, expected)
+	// Make sure removed extension from plugin 2-existingPlugin is removed
+	m.ioUtils.AssertCalled(t, "RemoveFile", "/2-dir/2-removedPath")
+	// Make sure entire directory for 3-removedPlugin is removed
+	m.ioUtils.AssertCalled(t, "RemoveAll", "/3-dir")
+}
+
+func TestPreparePluginsToInstallIsRemoteMustMatchLocal(t *testing.T) {
+	requested := []model.CachedPlugin{
+		generateCachedPlugin(t, "testPlugin", true, "testUrl", ""),
+	}
+	installed := []model.CachedPlugin{
+		generateCachedPlugin(t, "testPlugin", false, "testUrl", "/plugins/testExtension"),
+	}
+
+	m := initMocks()
+	m.ioUtils.On("RemoveFile", "/plugins/testExtension").Return(nil)
+
+	output := m.broker.preparePluginsToInstall(requested, installed)
+
+	assert.NotNil(t, output)
+	assert.ElementsMatch(t, output, requested)
+	// Plugin should be removed if IsRemote does not match
+	m.ioUtils.AssertCalled(t, "RemoveFile", "/plugins/testExtension")
+}
+
+func TestPreparePluginsToInstallIsRemoteMustMatchRemote(t *testing.T) {
+	requested := []model.CachedPlugin{
+		generateCachedPlugin(t, "testPlugin", false, "testUrl", ""),
+	}
+	installed := []model.CachedPlugin{
+		generateCachedPlugin(t, "testPlugin", true, "testUrl", "/plugins/sidecars/testPlugin/testExtension"),
+	}
+
+	m := initMocks()
+	m.ioUtils.On("RemoveAll", "/plugins/sidecars/testPlugin").Return(nil)
+
+	output := m.broker.preparePluginsToInstall(requested, installed)
+
+	assert.NotNil(t, output)
+	assert.ElementsMatch(t, output, requested)
+	// Plugin should be removed if IsRemote does not match
+	m.ioUtils.AssertCalled(t, "RemoveAll", "/plugins/sidecars/testPlugin")
+}
+
+func TestPreparePluginsToInstallLogsErrorOnRemoveAll(t *testing.T) {
+	testError := fmt.Errorf("test error)")
+
+	requested := []model.CachedPlugin{
+		generateCachedPlugin(t, "1-newPlugin", false, "1-newUrl", ""),
+		generateCachedPlugin(t, "2-existingPlugin", true, "2-existingUrl", "", "2-newUrl", ""),
+	}
+	installed := []model.CachedPlugin{
+		generateCachedPlugin(t, "3-removedPlugin", true, "3-removedUrl", "/3-dir/3-removedPath"),
+		generateCachedPlugin(t, "2-existingPlugin", true, "2-existingUrl", "/2-dir/2-existingPath", "2-oldUrl", "/2-dir/2-removedPath"),
+	}
+	expected := []model.CachedPlugin{
+		generateCachedPlugin(t, "1-newPlugin", false, "1-newUrl", ""),
+		generateCachedPlugin(t, "2-existingPlugin", true, "2-existingUrl", "/2-dir/2-existingPath", "2-newUrl", ""),
+	}
+
+	m := initMocks()
+	m.ioUtils.On("RemoveAll", "/3-dir").Return(testError)
+	m.ioUtils.On("RemoveFile", "/2-dir/2-removedPath").Return(nil)
+
+	output := m.broker.preparePluginsToInstall(requested, installed)
+
+	assert.NotNil(t, output)
+	assert.ElementsMatch(t, output, expected)
+	// Make sure removed extension from plugin 2-existingPlugin is removed
+	m.ioUtils.AssertCalled(t, "RemoveFile", "/2-dir/2-removedPath")
+	// Make sure entire directory for 3-removedPlugin is removed
+	m.ioUtils.AssertCalled(t, "RemoveAll", "/3-dir")
+	m.commonBroker.AssertCalled(t, "PrintInfo", "WARN: failed to remove plugin artifacts: %s", testError)
+}
+
+func TestPreparePluginsToInstallLogsErrorOnRemoveFile(t *testing.T) {
+	testError := fmt.Errorf("test error)")
+
+	requested := []model.CachedPlugin{
+		generateCachedPlugin(t, "1-newPlugin", false, "1-newUrl", ""),
+		generateCachedPlugin(t, "2-existingPlugin", false, "2-existingUrl", "", "2-newUrl", ""),
+	}
+	installed := []model.CachedPlugin{
+		generateCachedPlugin(t, "3-removedPlugin", true, "3-removedUrl", "/3-dir/3-removedPath"),
+		generateCachedPlugin(t, "2-existingPlugin", false, "2-existingUrl", "/2-dir/2-existingPath", "2-oldUrl", "/2-dir/2-removedPath"),
+	}
+	expected := []model.CachedPlugin{
+		generateCachedPlugin(t, "1-newPlugin", false, "1-newUrl", ""),
+		generateCachedPlugin(t, "2-existingPlugin", false, "2-existingUrl", "/2-dir/2-existingPath", "2-newUrl", ""),
+	}
+
+	m := initMocks()
+	m.ioUtils.On("RemoveAll", "/3-dir").Return(nil)
+	m.ioUtils.On("RemoveFile", "/2-dir/2-removedPath").Return(testError)
+
+	output := m.broker.preparePluginsToInstall(requested, installed)
+
+	assert.NotNil(t, output)
+	assert.ElementsMatch(t, output, expected)
+	// Make sure removed extension from plugin 2-existingPlugin is removed
+	m.ioUtils.AssertCalled(t, "RemoveFile", "/2-dir/2-removedPath")
+	// Make sure entire directory for 3-removedPlugin is removed
+	m.ioUtils.AssertCalled(t, "RemoveAll", "/3-dir")
+	m.commonBroker.AssertCalled(t, "PrintInfo", "WARN: Failed to clean up plugin at %s: %s", "/2-dir/2-removedPath", testError)
+}
+
+func TestReadInstalledPlugins(t *testing.T) {
+	installedJSON, installedJSONBytes := generateInstalledPluginJSON(t, installedPluginsJSONVersion)
+
+	m := initMocks()
+	m.ioUtils.On("ReadFile", installedPluginsJSONFile).Return(installedJSONBytes, nil)
+	m.ioUtils.On("RemoveFile", installedPluginsJSONFile).Return(nil)
+	m.ioUtils.On("FileExists", mock.Anything).Return(true)
+
+	actual, err := m.broker.readInstalledPlugins()
+
+	assert.Nil(t, err)
+	assert.ElementsMatch(t, installedJSON.Plugins, actual)
+	m.ioUtils.AssertCalled(t, "RemoveFile", installedPluginsJSONFile)
+}
+
+func TestReadInstalledPluginsFailureToReadFile(t *testing.T) {
+	testError := fmt.Errorf("test error")
+
+	m := initMocks()
+	m.ioUtils.On("ReadFile", installedPluginsJSONFile).Return(nil, testError)
+
+	_, err := m.broker.readInstalledPlugins()
+
+	assert.EqualError(t, err, "test error")
+}
+
+func TestReadInstalledPluginsFailureToRemoveFile(t *testing.T) {
+	_, installedJSONBytes := generateInstalledPluginJSON(t, installedPluginsJSONVersion)
+	testError := fmt.Errorf("test error")
+
+	m := initMocks()
+	m.ioUtils.On("ReadFile", installedPluginsJSONFile).Return(installedJSONBytes, nil)
+	m.ioUtils.On("RemoveFile", installedPluginsJSONFile).Return(testError)
+
+	_, err := m.broker.readInstalledPlugins()
+
+	assert.EqualError(t, err, "test error")
+	m.ioUtils.AssertCalled(t, "RemoveFile", installedPluginsJSONFile)
+}
+
+func TestReadInstalledPluginsMalformedJSON(t *testing.T) {
+	jsonBytes := []byte("{")
+
+	m := initMocks()
+	m.ioUtils.On("ReadFile", installedPluginsJSONFile).Return(jsonBytes, nil)
+	m.ioUtils.On("RemoveFile", installedPluginsJSONFile).Return(nil)
+
+	_, err := m.broker.readInstalledPlugins()
+
+	assert.NotNil(t, err)
+	m.ioUtils.AssertCalled(t, "RemoveFile", installedPluginsJSONFile)
+}
+
+func TestReadInstalledPluginsDifferentVersion(t *testing.T) {
+	_, installedJSONBytes := generateInstalledPluginJSON(t, "testVersion")
+
+	m := initMocks()
+	m.ioUtils.On("ReadFile", installedPluginsJSONFile).Return(installedJSONBytes, nil)
+	m.ioUtils.On("RemoveFile", installedPluginsJSONFile).Return(nil)
+
+	_, err := m.broker.readInstalledPlugins()
+
+	m.commonBroker.AssertCalled(t, "PrintInfo", "Installed plugins cache is incompatible with current version of plugin broker. All plugins will be redownloaded.")
+
+	assert.EqualError(t, err, "Installed plugins list is from previous version of broker")
+}
+
+func TestReadInstalledPluginsChecksFiles(t *testing.T) {
+	_, installedJSONBytes := generateInstalledPluginJSON(t, installedPluginsJSONVersion,
+		generateCachedPlugin(t, "plugin1", false, "url1", "file1"),
+		generateCachedPlugin(t, "plugin2", true, "url2", "file2", "url3", "file3"))
+
+	m := initMocks()
+	m.ioUtils.On("ReadFile", installedPluginsJSONFile).Return(installedJSONBytes, nil)
+	m.ioUtils.On("RemoveFile", installedPluginsJSONFile).Return(nil)
+	m.ioUtils.On("FileExists", mock.Anything).Return(true)
+
+	_, err := m.broker.readInstalledPlugins()
+	assert.Nil(t, err)
+	m.ioUtils.AssertCalled(t, "FileExists", "file1")
+	m.ioUtils.AssertCalled(t, "FileExists", "file2")
+	m.ioUtils.AssertCalled(t, "FileExists", "file3")
+}
+
+func TestReadInstalledPluginsChecksFilesPropagatesError(t *testing.T) {
+	_, installedJSONBytes := generateInstalledPluginJSON(t, installedPluginsJSONVersion)
+
+	m := initMocks()
+	m.ioUtils.On("ReadFile", installedPluginsJSONFile).Return(installedJSONBytes, nil)
+	m.ioUtils.On("RemoveFile", installedPluginsJSONFile).Return(nil)
+	m.ioUtils.On("FileExists", mock.Anything).Return(false)
+
+	_, err := m.broker.readInstalledPlugins()
+	assert.NotNil(t, err)
+}
+
+func TestWriteInstalledPlugins(t *testing.T) {
+	plugins := []model.CachedPlugin{
+		model.CachedPlugin{
+			ID:       "plugin1",
+			IsRemote: true,
+			CachedExtensions: map[string]string{
+				"pluginUrl": "pluginExt",
+			},
+		},
+		model.CachedPlugin{
+			ID:       "plugin2",
+			IsRemote: false,
+			CachedExtensions: map[string]string{
+				"firstPluginUrl":  "firstPluginExtension",
+				"secondPluginUrl": "secondPluginExtension",
+			},
+		},
+	}
+
+	m := initMocks()
+	m.ioUtils.On("WriteFile", mock.Anything, mock.Anything).Return(nil)
+
+	err := m.broker.writeInstalledPlugins(plugins)
+
+	assert.Nil(t, err)
+	m.ioUtils.AssertNumberOfCalls(t, "WriteFile", 1)
+	m.ioUtils.AssertCalled(t, "WriteFile", installedPluginsJSONFile, mock.MatchedBy(func(bytes []byte) bool {
+		var installedJSON model.InstalledPluginJSON
+		err := json.Unmarshal(bytes, &installedJSON)
+		if err != nil {
+			t.Fatal("Failed to unmarshal json")
+		}
+		if installedJSON.Version != installedPluginsJSONVersion {
+			return false
+		}
+		return assert.ElementsMatch(t, installedJSON.Plugins, plugins)
+	}))
+}
+
+func TestWriteInstalledPluginsErrorOnWriteFile(t *testing.T) {
+	expectedError := fmt.Errorf("test error")
+
+	m := initMocks()
+	m.ioUtils.On("WriteFile", mock.Anything, mock.Anything).Return(expectedError)
+
+	err := m.broker.writeInstalledPlugins([]model.CachedPlugin{})
+
+	assert.EqualError(t, err, "test error")
+}
+
+func TestResetPluginsDirectory(t *testing.T) {
+	m := initMocks()
+	m.ioUtils.On("GetFilesByGlob", mock.Anything).Return([]string{"file1", "file2"}, nil)
+	m.ioUtils.On("RemoveAll", mock.AnythingOfType("string")).Return(nil)
+
+	m.broker.resetPluginsDirectory()
+
+	m.ioUtils.AssertCalled(t, "RemoveAll", "file1")
+	m.ioUtils.AssertCalled(t, "RemoveAll", "file2")
+}
+
+func TestResetPluginsDirectoryFailureToGlob(t *testing.T) {
+	testError := fmt.Errorf("test error")
+	m := initMocks()
+	m.ioUtils.On("GetFilesByGlob", mock.Anything).Return(nil, testError)
+	m.ioUtils.On("RemoveAll", mock.AnythingOfType("string")).Return(nil)
+
+	m.broker.resetPluginsDirectory()
+
+	m.commonBroker.AssertCalled(t, "PrintInfo", "WARN: failed to clear /plugins directory. Error: %s", testError)
+}
+
+func TestResetPluginsDirectoryFailureToRemove(t *testing.T) {
+	testError := fmt.Errorf("test error")
+	m := initMocks()
+	m.ioUtils.On("GetFilesByGlob", mock.Anything).Return([]string{"file1", "file2"}, nil)
+	m.ioUtils.On("RemoveAll", mock.AnythingOfType("string")).Return(testError)
+
+	m.broker.resetPluginsDirectory()
+
+	m.ioUtils.AssertCalled(t, "RemoveAll", "file1")
+	m.ioUtils.AssertCalled(t, "RemoveAll", "file2")
+	m.commonBroker.AssertCalled(t, "PrintInfo", "WARN: failed to remove '%s'. Error: %s", "file1", testError)
+	m.commonBroker.AssertCalled(t, "PrintInfo", "WARN: failed to remove '%s'. Error: %s", "file2", testError)
+}
+
+func TestPreparePluginsRemoveLocalDoesNotAffectOthers(t *testing.T) {
+	localPlugin := generateCachedPlugin(t, "test/local", false,
+		"test.local1.url", "/plugins/testlocal_1",
+		"test.local2.url", "/plugins/testlocal_2")
+	removedLocalPlugin := generateCachedPlugin(t, "test/local_removed", false,
+		"test.local1.url.removed", "/plugins/testlocal_1_removed",
+		"test.local2.url.removed", "/plugins/testlocal_2_removed")
+	remotePlugin := generateCachedPlugin(t, "test/remote", true,
+		"test.remote1.url", "/plugins/sidecars/remote/remote_1",
+		"test.remote2.url", "/plugins/sidecars/remote/remote_2")
+	removedRemotePlugin := generateCachedPlugin(t, "test/remote_removed", true,
+		"test.remote1.url.removed", "/plugins/sidecars/remote_removed/remote_1",
+		"test.remote2.url.removed", "/plugins/sidecars/remote_removed/remote_2")
+	unaffectedPaths := []string{
+		"/plugins/testlocal_1",
+		"/plugins/testlocal_2",
+		"/plugins/sidecars/remote/remote_1",
+		"/plugins/sidecars/remote/remote_2",
+	}
+
+	tests := []struct {
+		name      string
+		installed []model.CachedPlugin
+		requested []model.CachedPlugin
+	}{
+		{
+			name:      "Remove local plugin",
+			installed: []model.CachedPlugin{localPlugin, removedLocalPlugin, remotePlugin},
+			requested: []model.CachedPlugin{localPlugin, remotePlugin},
+		},
+		{
+			name:      "Remove remote plugin",
+			installed: []model.CachedPlugin{localPlugin, remotePlugin, removedRemotePlugin},
+			requested: []model.CachedPlugin{localPlugin, remotePlugin},
+		},
+		{
+			name:      "Remove local and remote plugin",
+			installed: []model.CachedPlugin{localPlugin, removedLocalPlugin, remotePlugin, removedRemotePlugin},
+			requested: []model.CachedPlugin{localPlugin, remotePlugin},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := initMocks()
+			m.ioUtils.On("RemoveFile", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+				removedPath := args.String(0)
+				assert.NotContainsf(t, removedPath, unaffectedPaths,
+					"Remove should not remove file in other plugin %s", removedPath)
+			})
+			m.ioUtils.On("RemoveAll", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+				removed := args.String(0)
+				for _, unaffected := range unaffectedPaths {
+					assert.Falsef(t, strings.HasPrefix(unaffected, removed),
+						"Should not remove directory (%s) containing other plugin's extensions: %s", removed, unaffected)
+				}
+			})
+			m.broker.preparePluginsToInstall(tt.requested, tt.installed)
+		})
+	}
+}
+
+func generateCachedPlugin(t *testing.T, ID string, isRemote bool, cached ...string) model.CachedPlugin {
+	plugin := model.CachedPlugin{
+		ID:               ID,
+		IsRemote:         isRemote,
+		CachedExtensions: make(map[string]string),
+	}
+	for i := 0; i < len(cached); i += 2 {
+		plugin.CachedExtensions[cached[i]] = cached[i+1]
+	}
+	return plugin
+}
+
+func generateInstalledPluginJSON(t *testing.T, version string, plugins ...model.CachedPlugin) (model.InstalledPluginJSON, []byte) {
+	if plugins == nil {
+		plugins = []model.CachedPlugin{generateCachedPlugin(t, "TestPlugin", true, "testUrl", "testExt")}
+	}
+	pluginsJSON := model.InstalledPluginJSON{
+		Version: version,
+		Plugins: plugins,
+	}
+	pluginsJSONBytes, err := json.MarshalIndent(pluginsJSON, "", "  ")
+	if err != nil {
+		t.Fatal("Failed to marshal json")
+	}
+	return pluginsJSON, pluginsJSONBytes
+}

--- a/brokers/artifacts/extensions.go
+++ b/brokers/artifacts/extensions.go
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package artifacts
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/eclipse/che-plugin-broker/model"
+	"github.com/eclipse/che-plugin-broker/utils"
+)
+
+// ProcessPlugin downloads all undownloaded plugin extensions and places the
+// relevant artifacts in their appropriate location in the /plugins directory.
+// If a plugin already has artifacts downloaded for a given extension, that
+// extension is skipped.
+func (b *Broker) ProcessPlugin(plugin *model.CachedPlugin) error {
+	workDir, err := b.ioUtils.TempDir("", "artifacts-broker")
+	if err != nil {
+		return err
+	}
+
+	// Workaround: messages can be displayed out of order in the workspace loading page
+	// Collect messages in a buffer and print them as a single string when needed.
+	logBuf := make([]string, 0)
+	defer b.flushLog(&logBuf)
+
+	logBuf = append(logBuf, fmt.Sprintf("Processing plugin %s", plugin.ID))
+	numExtensions := len(plugin.CachedExtensions)
+	extensionIdx := 0
+	for URL, path := range plugin.CachedExtensions {
+		extensionIdx = extensionIdx + 1
+		logBuf = append(logBuf, fmt.Sprintf("  Installing plugin extension %d/%d", extensionIdx, numExtensions))
+		if path != "" {
+			logBuf = append(logBuf, fmt.Sprintf("    Plugin already downloaded"))
+			continue
+		}
+		logBuf = append(logBuf, fmt.Sprintf("    Downloading plugin from %s", URL))
+		logBuf = b.flushLog(&logBuf)
+		archivePath, err := b.downloadArchive(URL, plugin.ID, workDir)
+		if err != nil {
+			return err
+		}
+		pluginPath, err := b.injectPlugin(plugin, archivePath)
+		if err != nil {
+			return err
+		}
+		plugin.CachedExtensions[URL] = pluginPath
+	}
+	return nil
+}
+
+func (b *Broker) downloadArchive(URL string, pluginID string, workDir string) (string, error) {
+	archivePath := b.ioUtils.ResolveDestPathFromURL(URL, workDir)
+	archivePath, err := b.ioUtils.Download(URL, archivePath, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to download plugin from %s: %s", URL, err)
+	}
+	return archivePath, nil
+}
+
+func (b *Broker) injectPlugin(plugin *model.CachedPlugin, archivePath string) (string, error) {
+	pluginPath := "/plugins"
+
+	if plugin.IsRemote {
+		pluginUniqueName := utils.ConvertIDToUniqueName(plugin.ID)
+		pluginPath = filepath.Join(pluginPath, "sidecars", pluginUniqueName)
+		err := b.ioUtils.MkDir(pluginPath)
+		if err != nil {
+			return "", err
+		}
+	}
+	pluginArchiveName := b.generatePluginArchiveName(plugin, archivePath)
+	pluginArchivePath := filepath.Join(pluginPath, pluginArchiveName)
+	err := b.ioUtils.CopyFile(archivePath, pluginArchivePath)
+	if err != nil {
+		return "", err
+	}
+
+	return pluginArchivePath, nil
+}
+
+func (b *Broker) flushLog(bufferRef *[]string) []string {
+	buffer := *bufferRef
+	b.PrintInfoBuffer(buffer)
+	return buffer[:0]
+}
+
+func (b *Broker) generatePluginArchiveName(plugin *model.CachedPlugin, archivePath string) string {
+	archiveName := filepath.Base(archivePath)
+	formattedID := strings.ReplaceAll(plugin.ID, "/", ".")
+	return fmt.Sprintf("%s.%s.%s", formattedID, b.rand.String(10), archiveName)
+}

--- a/brokers/artifacts/extensions_test.go
+++ b/brokers/artifacts/extensions_test.go
@@ -1,0 +1,179 @@
+//
+// Copyright (c) 2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package artifacts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eclipse/che-plugin-broker/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestProcessPluginDoesNothingWhenNoExtensions(t *testing.T) {
+	m := initMocks()
+	m.ioUtils.On("TempDir", mock.Anything, mock.Anything).Return("testDir", nil)
+
+	plugin := model.CachedPlugin{
+		ID:               "testPlugin",
+		IsRemote:         true,
+		CachedExtensions: map[string]string{},
+	}
+
+	output := m.broker.ProcessPlugin(&plugin)
+
+	assert.Nil(t, output)
+	m.ioUtils.AssertNotCalled(t, "Download", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestProcessPluginSuccessfulCase(t *testing.T) {
+	m := initMocks()
+	m.ioUtils.On("TempDir", mock.Anything, mock.Anything).Return("testDir", nil)
+	m.ioUtils.On("ResolveDestPathFromURL", "testUrl", "testDir").Return("testDestPath")
+	m.ioUtils.On("Download", "testUrl", "testDestPath", mock.AnythingOfType("bool")).Return("testArchivePath", nil)
+	m.ioUtils.On("MkDir", mock.AnythingOfType("string")).Return(nil)
+	m.ioUtils.On("CopyFile", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
+	m.rand.On("String", mock.AnythingOfType("int")).Return("randstr")
+
+	plugin := model.CachedPlugin{
+		ID:       "testPlugin",
+		IsRemote: true,
+		CachedExtensions: map[string]string{
+			"testUrl": "",
+		},
+	}
+
+	err := m.broker.ProcessPlugin(&plugin)
+
+	assert.Nil(t, err)
+}
+
+func TestProcessPluginHandlesPartiallyCachedPlugin(t *testing.T) {
+	m := initMocks()
+	m.ioUtils.On("TempDir", mock.Anything, mock.Anything).Return("testDir", nil)
+	m.ioUtils.On("ResolveDestPathFromURL", "testUrl", "testDir").Return("testDestPath")
+	m.ioUtils.On("Download", "testUrl", "testDestPath", mock.AnythingOfType("bool")).Return("testArchivePath", nil)
+	m.ioUtils.On("MkDir", mock.AnythingOfType("string")).Return(nil)
+	m.ioUtils.On("CopyFile", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
+	m.rand.On("String", mock.AnythingOfType("int")).Return("randstr")
+
+	plugin := model.CachedPlugin{
+		ID:       "testPlugin",
+		IsRemote: true,
+		CachedExtensions: map[string]string{
+			"alreadyCached": "alreadyCached",
+			"testUrl":       "",
+		},
+	}
+
+	err := m.broker.ProcessPlugin(&plugin)
+
+	assert.Nil(t, err)
+	m.ioUtils.AssertNotCalled(t, "Download", "alreadyCached", mock.Anything, mock.Anything)
+}
+
+func TestProcessPluginIgnoresCachedPlugins(t *testing.T) {
+	m := initMocks()
+	m.ioUtils.On("TempDir", mock.Anything, mock.Anything).Return("testDir", nil)
+	m.ioUtils.On("ResolveDestPathFromURL", "testUrl", "testDir").Return("testDestPath")
+	m.ioUtils.On("Download", "testUrl", "testDestPath", mock.AnythingOfType("bool")).Return("testArchivePath", nil)
+	m.ioUtils.On("MkDir", mock.AnythingOfType("string")).Return(nil)
+	m.ioUtils.On("CopyFile", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
+	m.rand.On("String", mock.AnythingOfType("int")).Return("randstr")
+
+	plugin := model.CachedPlugin{
+		ID:       "testPlugin",
+		IsRemote: true,
+		CachedExtensions: map[string]string{
+			"testUrl": "existingPathToPlugin",
+		},
+	}
+
+	err := m.broker.ProcessPlugin(&plugin)
+
+	assert.Nil(t, err)
+	m.ioUtils.AssertNotCalled(t, "Download", mock.Anything, mock.Anything, mock.Anything)
+	m.ioUtils.AssertNotCalled(t, "MkDir", mock.Anything)
+	m.ioUtils.AssertNotCalled(t, "CopyFile", mock.Anything, mock.Anything)
+}
+
+func TestProcessPluginFailureOnDownload(t *testing.T) {
+	testError := fmt.Errorf("test error")
+
+	m := initMocks()
+	m.ioUtils.On("TempDir", mock.Anything, mock.Anything).Return("testDir", nil)
+	m.ioUtils.On("ResolveDestPathFromURL", "testUrl", "testDir").Return("testDestPath")
+	m.ioUtils.On("Download", "testUrl", "testDestPath", mock.AnythingOfType("bool")).Return("", testError)
+
+	plugin := model.CachedPlugin{
+		ID:       "testPlugin",
+		IsRemote: true,
+		CachedExtensions: map[string]string{
+			"testUrl": "",
+		},
+	}
+
+	err := m.broker.ProcessPlugin(&plugin)
+
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "failed to download plugin from testUrl: test error")
+}
+
+func TestProcessPluginFailureOnMkdir(t *testing.T) {
+	testError := fmt.Errorf("test error")
+
+	m := initMocks()
+	m.ioUtils.On("TempDir", mock.Anything, mock.Anything).Return("testDir", nil)
+	m.ioUtils.On("ResolveDestPathFromURL", "testUrl", "testDir").Return("testDestPath")
+	m.ioUtils.On("Download", "testUrl", "testDestPath", mock.AnythingOfType("bool")).Return("testArchivePath", nil)
+	m.ioUtils.On("MkDir", mock.AnythingOfType("string")).Return(testError)
+
+	plugin := model.CachedPlugin{
+		ID:       "testPlugin",
+		IsRemote: true,
+		CachedExtensions: map[string]string{
+			"testUrl": "",
+		},
+	}
+
+	err := m.broker.ProcessPlugin(&plugin)
+
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "test error")
+}
+
+func TestProcessPluginFailureOnCopyFile(t *testing.T) {
+	testError := fmt.Errorf("test error")
+
+	m := initMocks()
+	m.ioUtils.On("TempDir", mock.Anything, mock.Anything).Return("testDir", nil)
+	m.ioUtils.On("ResolveDestPathFromURL", "testUrl", "testDir").Return("testDestPath")
+	m.ioUtils.On("Download", "testUrl", "testDestPath", mock.AnythingOfType("bool")).Return("testArchivePath", nil)
+	m.ioUtils.On("MkDir", mock.AnythingOfType("string")).Return(nil)
+	m.rand.On("String", mock.AnythingOfType("int")).Return("randstr")
+	m.ioUtils.On("CopyFile", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(testError)
+
+	plugin := model.CachedPlugin{
+		ID:       "testPlugin",
+		IsRemote: true,
+		CachedExtensions: map[string]string{
+			"testUrl": "",
+		},
+	}
+
+	err := m.broker.ProcessPlugin(&plugin)
+
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "test error")
+}

--- a/brokers/testdata/config-plugin-ids.json
+++ b/brokers/testdata/config-plugin-ids.json
@@ -14,5 +14,8 @@
   },
   {
     "id": "redhat-developer/che-omnisharp-plugin/0.0.1"
+  },
+  {
+    "id": "joaompinto/vscode-asciidoctor/2.7.7"
   }
 ]

--- a/brokers/testdata/non-remote-vscode-ext.yaml
+++ b/brokers/testdata/non-remote-vscode-ext.yaml
@@ -1,0 +1,5 @@
+id: test-plugin
+type: VS Code extension
+spec:
+  extensions:
+  - "https://my-extension.url"

--- a/brokers/testdata/remote-vscode-ext.yaml
+++ b/brokers/testdata/remote-vscode-ext.yaml
@@ -1,0 +1,8 @@
+id: test-plugin
+type: VS Code extension
+spec:
+  containers:
+  - name: test-plugin-container
+    image: "myregistry.io/mycontainer"
+  extensions:
+  - "https://my-extension.url"

--- a/common/broker.go
+++ b/common/broker.go
@@ -38,6 +38,7 @@ type Broker interface {
 	PrintPlan(metas []model.PluginMeta)
 	PrintDebug(format string, v ...interface{})
 	PrintInfo(format string, v ...interface{})
+	PrintInfoBuffer(info []string)
 	// It is not convenient in tests with mocks.
 	// It should exit current context but when mocked it does not exit.
 	// Instead use: PubLog, log.Fatal

--- a/common/events.go
+++ b/common/events.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/eclipse/che-plugin-broker/cfg"
@@ -74,6 +75,14 @@ func (broker *brokerImpl) PrintInfo(format string, v ...interface{}) {
 	message := fmt.Sprintf(format, v...)
 	broker.PubLog(message)
 	log.Print(message)
+}
+
+func (broker *brokerImpl) PrintInfoBuffer(buffer []string) {
+	message := strings.Join(buffer, "\n")
+	broker.PubLog(message)
+	for _, line := range buffer {
+		log.Print(line)
+	}
 }
 
 func (broker *brokerImpl) PrintFatal(format string, v ...interface{}) {

--- a/common/mocks/Broker.go
+++ b/common/mocks/Broker.go
@@ -57,6 +57,11 @@ func (_m *Broker) PrintInfo(format string, v ...interface{}) {
 	_m.Called(_ca...)
 }
 
+// PrintInfoBuffer provides a mock function with given fields: info
+func (_m *Broker) PrintInfoBuffer(info []string) {
+	_m.Called(info)
+}
+
 // PrintPlan provides a mock function with given fields: metas
 func (_m *Broker) PrintPlan(metas []model.PluginMeta) {
 	_m.Called(metas)

--- a/model/model.go
+++ b/model/model.go
@@ -115,3 +115,22 @@ type ChePlugin struct {
 	WorkspaceEnv   []EnvVar    `json:"workspaceEnv" yaml:"workspaceEnv"`
 	Type           string      `json:"type" yaml:"type"`
 }
+
+// CachedPlugin represents an "installed" plugin on the filesystem.
+// Contains a plugin ID and the extensions it has stored in /plugins
+// CachedExtensions is a map of extension URL -> filesystem path, where
+// the filesystem path may be an empty string if the extension has not yet
+// been downloaded.
+type CachedPlugin struct {
+	ID               string            `json:"pluginId" yaml:"pluginId"`
+	IsRemote         bool              `json:"isRemote" yaml:"isRemote"`
+	CachedExtensions map[string]string `json:"cachedExtensions" yaml:"cachedExtensions"`
+}
+
+// InstalledPluginJSON represents the JSON object to be stored when tracking
+// plugins installed in the current workspace, consisting of a list of cached
+// plugins and a version number to track compatibility.
+type InstalledPluginJSON struct {
+	Version string         `json:"version" yaml:"version"`
+	Plugins []CachedPlugin `json:"plugins" yaml:"plugins"`
+}

--- a/utils/ioutil.go
+++ b/utils/ioutil.go
@@ -44,6 +44,10 @@ type IoUtil interface {
 	Fetch(url string) ([]byte, error)
 	GetFilesByGlob(glob string) ([]string, error)
 	RemoveAll(path string) error
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, data []byte) error
+	RemoveFile(path string) error
+	FileExists(path string) bool
 }
 
 type impl struct {
@@ -314,7 +318,7 @@ func (util *impl) GetFilesByGlob(glob string) ([]string, error) {
 	return filepath.Glob(glob)
 }
 
-// DeleteFiles is a wrapper around os.RemoveAll() to allow mocking in tests
+// RemoveAll is a wrapper around os.RemoveAll() to allow mocking in tests
 func (util *impl) RemoveAll(path string) error {
 	return os.RemoveAll(path)
 }
@@ -324,4 +328,27 @@ func Close(c io.Closer) {
 	if err != nil {
 		log.Println(err)
 	}
+}
+
+// ReadFile is a wrapper around ioutil.ReadFile() to allow mocking in tests
+func (util *impl) ReadFile(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
+}
+
+// DumpFile is a wrapper around ioutil.WriteFile() to allow mocking in tests.
+// Writes files with 0666 permissions.
+func (util *impl) WriteFile(path string, data []byte) error {
+	return ioutil.WriteFile(path, data, 0666)
+}
+
+// RemoveFile is a wrapper around os.Remove to allow mocking in tests.
+func (util *impl) RemoveFile(path string) error {
+	return os.Remove(path)
+}
+
+// FileExists checks if a file exists using os.Stat. If os.Stat returns any error,
+// false is returned.
+func (util *impl) FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/utils/mocks/IoUtil.go
+++ b/utils/mocks/IoUtil.go
@@ -96,6 +96,20 @@ func (_m *IoUtil) Fetch(url string) ([]byte, error) {
 	return r0, r1
 }
 
+// FileExists provides a mock function with given fields: path
+func (_m *IoUtil) FileExists(path string) bool {
+	ret := _m.Called(path)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // GetFilesByGlob provides a mock function with given fields: glob
 func (_m *IoUtil) GetFilesByGlob(glob string) ([]string, error) {
 	ret := _m.Called(glob)
@@ -133,8 +147,45 @@ func (_m *IoUtil) MkDir(_a0 string) error {
 	return r0
 }
 
+// ReadFile provides a mock function with given fields: path
+func (_m *IoUtil) ReadFile(path string) ([]byte, error) {
+	ret := _m.Called(path)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = rf(path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RemoveAll provides a mock function with given fields: path
 func (_m *IoUtil) RemoveAll(path string) error {
+	ret := _m.Called(path)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// RemoveFile provides a mock function with given fields: path
+func (_m *IoUtil) RemoveFile(path string) error {
 	ret := _m.Called(path)
 
 	var r0 error
@@ -217,6 +268,20 @@ func (_m *IoUtil) Unzip(arch string, dest string) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string) error); ok {
 		r0 = rf(arch, dest)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// WriteFile provides a mock function with given fields: path, data
+func (_m *IoUtil) WriteFile(path string, data []byte) error {
+	ret := _m.Called(path, data)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, []byte) error); ok {
+		r0 = rf(path, data)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/utils/plugin_names.go
+++ b/utils/plugin_names.go
@@ -25,3 +25,8 @@ var re = regexp.MustCompile(`[^a-zA-Z_0-9]+`)
 func GetPluginUniqueName(meta model.PluginMeta) string {
 	return re.ReplaceAllString(meta.Publisher+"_"+meta.Name+"_"+meta.Version, `_`)
 }
+
+// ConvertIDToUniqueName converts a plugin ID to a unique plugin name
+func ConvertIDToUniqueName(id string) string {
+	return re.ReplaceAllString(id, "_")
+}


### PR DESCRIPTION
### What does this PR do?
Allows caching of installed plugin extensions in the workspace. Instead of erasing the entire `/plugins` directory on every start, the broker will instead store a json log of installed plugins, and use this to only download required extensions, via the rule:

1. If a plugin is installed locally but not in the current workspace, all of its artifacts are removed
2. If a plugin is not installed locally and included in the current workspace, all of its artifacts will be downloaded
3. If a plugin is installed but the artifacts to be downloaded are different compared to a prior run (e.g. a new version of `latest`), then 
    - Extensions that are no longer needed are removed
    - New extensions are downloaded
    - Extensions that are shared between the old and new version are reused.

These changes make the assumption that all extension artifacts are served from unique URLs, and will fail if e.g. the `.vsix` file at a URL is updated.

Installed plugin metadata is stored in a new struct (see `model.InstalledPlugin`), which stores the plugin ID, whether the plugin is remote (runs in a sidecar), and a map of extension URLs to filesystem paths. A list of installed plugins is saved in the `/plugins` directory along with an internal file version number to allow versioned changes.

This PR significantly improves brokering time for the most common use case in starting a workspace, where a previously started non-ephemeral workspace is started a second time; in this case brokering is complete almost immediately, since nothing needs to be downloaded.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15470