### PR TITLE
update base images and switch to scratch 

### DIFF
--- a/build/artifacts/rhel.Dockerfile
+++ b/build/artifacts/rhel.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -10,8 +10,8 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.11.13-11 as builder
-ENV PATH=/opt/rh/go-toolset-1.11/root/usr/bin:$PATH \
+FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.12.12-4 as builder
+ENV PATH=/opt/rh/go-toolset-1.12/root/usr/bin:$PATH \
     GOPATH=/go/
 USER root
 WORKDIR /go/src/github.com/eclipse/che-plugin-broker/brokers/artifacts/cmd/
@@ -20,9 +20,14 @@ RUN adduser appuser && \
     CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -installsuffix cgo -o artifacts-broker main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.0-213
+FROM registry.access.redhat.com/ubi8-minimal:8.1-398
 
 USER appuser
+# CRW-528 copy actual cert
+COPY --from=builder /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
+# CRW-528 copy symlink to the above cert
+COPY --from=builder /etc/pki/tls/certs/ca-bundle.crt                  /etc/pki/tls/certs/
+
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/src/github.com/eclipse/che-plugin-broker/brokers/artifacts/cmd/artifacts-broker /
 ENTRYPOINT ["/artifacts-broker"]

--- a/build/metadata/rhel.Dockerfile
+++ b/build/metadata/rhel.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -10,8 +10,8 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.11.13-11 as builder
-ENV PATH=/opt/rh/go-toolset-1.11/root/usr/bin:$PATH \
+FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.12.12-4 as builder
+ENV PATH=/opt/rh/go-toolset-1.12/root/usr/bin:$PATH \
     GOPATH=/go/
 USER root
 WORKDIR /go/src/github.com/eclipse/che-plugin-broker/brokers/metadata/cmd/
@@ -20,9 +20,14 @@ RUN adduser appuser && \
     CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -installsuffix cgo -o metadata-broker main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.0-213
+FROM registry.access.redhat.com/ubi8-minimal:8.1-398
 
 USER appuser
+# CRW-528 copy actual cert
+COPY --from=builder /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
+# CRW-528 copy symlink to the above cert
+COPY --from=builder /etc/pki/tls/certs/ca-bundle.crt                  /etc/pki/tls/certs/
+
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/src/github.com/eclipse/che-plugin-broker/brokers/metadata/cmd/metadata-broker /
 ENTRYPOINT ["/metadata-broker"]


### PR DESCRIPTION
update base images and copyright; switch to scratch image then add certs (rather than ubi8-minimal) as per fix in https://issues.redhat.com/browse/CRW-528

Change-Id: I2cca65d177505e5cb934dc5bd246367112b3ac74
Signed-off-by: nickboldt <nboldt@redhat.com>