### PR TITLE
Check plugins' extensions for conflicts during metadata broker

### DIFF
--- a/brokers/metadata/broker.go
+++ b/brokers/metadata/broker.go
@@ -28,7 +28,6 @@ import (
 const RegistryURLFormat = "%s/%s/meta.yaml"
 
 // Broker is used to process Che plugins
-// Broker is used to process Che plugins
 type Broker struct {
 	common.Broker
 	Storage          storage.Storage
@@ -71,6 +70,13 @@ func (b *Broker) Start(pluginFQNs []model.PluginFQN, defaultRegistry string) err
 		return b.fail(fmt.Errorf("Failed to download plugin meta: %s", err))
 	}
 	b.PrintPlan(pluginMetas)
+
+	if collisions := utils.GetExtensionCollisions(pluginMetas); len(collisions) > 0 {
+		collisionLog := []string{"WARNING: multiple instances of the same extension will be included in this workspace:"}
+		collisionLog = append(collisionLog, utils.ConvertCollisionsToLog(collisions)...)
+		collisionLog = append(collisionLog, "These plugins may not work as expected. If errors occur please try disabling all but one of the conflicting plugins.")
+		b.PrintInfoBuffer(collisionLog)
+	}
 
 	// Process plugins into ChePlugins
 	err = b.ProcessPlugins(pluginMetas)

--- a/brokers/testdata/config-plugin-ids.json
+++ b/brokers/testdata/config-plugin-ids.json
@@ -3,6 +3,9 @@
     "id": "ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17"
   },
   {
+    "id": "redhat/vscode-openshift-connector/0.1.2"
+  },
+  {
     "id": "eclipse/che-machine-exec-plugin/0.0.1"
   },
   {

--- a/utils/dependencies.go
+++ b/utils/dependencies.go
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+// GetExtensionCollisions checks a list of plugin metas for extensions shared by
+// more than one plugin. Return value is a list of
+func GetExtensionCollisions(metas []model.PluginMeta) map[string][]string {
+	extensions := map[string][]string{}
+	for _, meta := range metas {
+		for _, ext := range meta.Spec.Extensions {
+			extensions[ext] = append(extensions[ext], meta.ID)
+		}
+	}
+	collisions := make(map[string][]string)
+	for ext, ids := range extensions {
+		if len(ids) > 1 {
+			collisions[ext] = ids
+		}
+	}
+	return collisions
+}
+
+// ConvertCollisionsToLog converts the output of GetExtensionCollisions to a human-readable
+// string. Output is a slice of strings, to be joined by newlines
+func ConvertCollisionsToLog(collisions map[string][]string) []string {
+	var output []string
+	for ext, plugins := range collisions {
+		output = append(output, fmt.Sprintf("  Plugins"))
+		for _, plugin := range plugins {
+			output = append(output, fmt.Sprintf("    - %s", plugin))
+		}
+		if len(plugins) > 2 {
+			output = append(output, fmt.Sprintf("  all depend on and embed extension"))
+		} else {
+			output = append(output, fmt.Sprintf("  both depend on and embed extension"))
+		}
+		output = append(output, fmt.Sprintf("    %s", ext))
+	}
+	return output
+}

--- a/utils/dependencies_test.go
+++ b/utils/dependencies_test.go
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+func TestGetExtensionCollisions(t *testing.T) {
+	metas := []model.PluginMeta{
+		generateMetaWithExtensions("test/conflict_one", "aaa", "bbb"),
+		generateMetaWithExtensions("test/no_conflict", "ddd"),
+		generateMetaWithExtensions("test/conflict_two", "ccc", "bbb"),
+	}
+
+	output := GetExtensionCollisions(metas)
+	assert.NotEmpty(t, output)
+	assert.ElementsMatch(t, output["bbb"], []string{"test/conflict_one", "test/conflict_two"})
+	assert.NotContains(t, output, "aaa")
+	assert.NotContains(t, output, "ccc")
+	assert.NotContains(t, output, "ddd")
+}
+
+func TestGetExtensionCollisionsMulti(t *testing.T) {
+	metas := []model.PluginMeta{
+		generateMetaWithExtensions("one", "aaa", "bbb"),
+		generateMetaWithExtensions("two", "xxx", "bbb"),
+		generateMetaWithExtensions("three", "aaa", "yyy"),
+	}
+
+	output := GetExtensionCollisions(metas)
+	assert.NotEmpty(t, output)
+	assert.ElementsMatch(t, output["aaa"], []string{"one", "three"})
+	assert.ElementsMatch(t, output["bbb"], []string{"one", "two"})
+	assert.NotContains(t, output, "xxx")
+	assert.NotContains(t, output, "yyy")
+}
+
+func TestConvertCollisionsToLog(t *testing.T) {
+	collisions := map[string][]string{
+		"ext1": []string{"plugin_a", "plugin_b"},
+		"ext2": []string{"plugin_c", "plugin_d", "plugin_e"},
+	}
+	output := ConvertCollisionsToLog(collisions)
+	for _, test := range []string{
+		".*ext1.*", ".*ext2.*", ".*plugin_a.*", ".*plugin_b.*", ".*plugin_c.*", ".*plugin_d.*", ".*plugin_e.*",
+	} {
+		assertMatchSliceRegexp(t, output, test)
+	}
+}
+
+func generateMetaWithExtensions(id string, exts ...string) model.PluginMeta {
+	return model.PluginMeta{
+		ID: id,
+		Spec: model.PluginMetaSpec{
+			Extensions: exts,
+		},
+	}
+}
+
+func assertMatchSliceRegexp(t *testing.T, slice []string, pattern string) {
+	re := regexp.MustCompile(pattern)
+	match := false
+	for _, str := range slice {
+		if re.MatchString(str) {
+			match = true
+		}
+	}
+	assert.Truef(t, match, "Expected '%s' to be logged but got:\n%s", pattern, strings.Join(slice, "\n"))
+}


### PR DESCRIPTION
### What does this PR do?
During metadata brokering process, check plugins for conflicting extensions (i.e. two plugins use the same extension), and warn user in case of conflict. 

Sample output:
```
List of plugins and editors to install
- redhat/java11/latest - Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
- ms-kubernetes-tools/vscode-kubernetes-tools/latest - Develop, deploy and debug Kubernetes applications
- redhat/vscode-openshift-connector/latest - Interacting with Red Hat OpenShift clusters and providing a streamlined developer experience using Eclipse Che
- eclipse/che-machine-exec-plugin/7.8.0 - Che Plug-in with che-machine-exec service to provide creation terminal or tasks for Eclipse CHE workspace containers.
- eclipse/che-theia/7.8.0 - Eclipse Theia
Warning: some plugins in this workspace have conflicting dependencies:
    Plugins
        {ms-kubernetes-tools/vscode-kubernetes-tools/latest, redhat/vscode-openshift-connector/latest}
    conflict on extension
        https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-kubernetes-tools/vscode-kubernetes-tools-1.0.9.vsix
    Plugins
        {ms-kubernetes-tools/vscode-kubernetes-tools/latest, redhat/vscode-openshift-connector/latest}
    conflict on extension
        https://github.com/redhat-developer/vscode-yaml/releases/download/0.4.0/redhat.vscode-yaml-0.4.0.vsix
If you encounter issues with plugins, please disable conflicting plugins above.
All plugin metadata has been successfully processed
```

The current approach is limited to matching URLs; as a result it can miss some conflicts (e.g. different URLs for the same extension or different versions of the same extension).

Additionally, due to https://github.com/eclipse/che/issues/15758, sometimes the order of messages can sometimes be confused slightly.

### What issues does this PR fix or reference?
Component of https://github.com/eclipse/che/issues/15966