### PR TITLE
Cleanup

### DIFF
--- a/.cico/cico_build_ci.sh
+++ b/.cico/cico_build_ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2012-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.cico/cico_build_nightly.sh
+++ b/.cico/cico_build_nightly.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2012-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.cico/cico_build_release.sh
+++ b/.cico/cico_build_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2012-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.cico/cico_functions.sh
+++ b/.cico/cico_functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,11 @@ dep-update:
 
 .PHONY: build-docker-artifacts
 build-docker-artifacts:
-	docker build -t eclipse/che-plugin-artifacts-broker:latest -f build/artifacts/Dockerfile .
+	docker build -t quay.io/eclipse/che-plugin-artifacts-broker:latest -f build/artifacts/Dockerfile .
 
 .PHONY: build-docker-metadata
 build-docker-metadata:
-	docker build -t eclipse/che-plugin-metadata-broker:latest -f build/metadata/Dockerfile .
+	docker build -t quay.io/eclipse/che-plugin-metadata-broker:latest -f build/metadata/Dockerfile .
 
 .PHONY: test-metadata
 test-metadata:

--- a/brokers/artifacts/broker.go
+++ b/brokers/artifacts/broker.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/artifacts/broker_test.go
+++ b/brokers/artifacts/broker_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/artifacts/cache.go
+++ b/brokers/artifacts/cache.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/artifacts/cache_test.go
+++ b/brokers/artifacts/cache_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/artifacts/cmd/main.go
+++ b/brokers/artifacts/cmd/main.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/artifacts/extensions.go
+++ b/brokers/artifacts/extensions.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/artifacts/extensions_test.go
+++ b/brokers/artifacts/extensions_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/metadata/broker.go
+++ b/brokers/metadata/broker.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/metadata/broker_test.go
+++ b/brokers/metadata/broker_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/metadata/cmd/main.go
+++ b/brokers/metadata/cmd/main.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/metadata/remote_runtime_provisioner.go
+++ b/brokers/metadata/remote_runtime_provisioner.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/metadata/remote_runtime_provisioner_test.go
+++ b/brokers/metadata/remote_runtime_provisioner_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/brokers/metadata/sidecar_provisioner_test.go
+++ b/brokers/metadata/sidecar_provisioner_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/CI/Dockerfile
+++ b/build/CI/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/artifacts/Dockerfile
+++ b/build/artifacts/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dev/Dockerfile
+++ b/build/dev/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/metadata/Dockerfile
+++ b/build/metadata/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/common/broker.go
+++ b/common/broker.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/common/connect.go
+++ b/common/connect.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/common/events.go
+++ b/common/events.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/common/random.go
+++ b/common/random.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/model/events.go
+++ b/model/events.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/model/model.go
+++ b/model/model.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/model/plugin_types.go
+++ b/model/plugin_types.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/utils/error.go
+++ b/utils/error.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/utils/ioutil.go
+++ b/utils/ioutil.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/utils/ioutil_test.go
+++ b/utils/ioutil_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/utils/metadata_resolver_test.go
+++ b/utils/metadata_resolver_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/utils/mocks/MockHttpClient.go
+++ b/utils/mocks/MockHttpClient.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Red Hat, Inc.
+// Copyright (c) 2018-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/utils/plugin_names.go
+++ b/utils/plugin_names.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/utils/plugin_types.go
+++ b/utils/plugin_types.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/utils/validator_test.go
+++ b/utils/validator_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Red Hat, Inc.
+// Copyright (c) 2019-2020 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
### What does this PR do?
Cleanup brokers codebase:
- Set license years to 2020
- Use quay.io image registry in makefile to match where images are normally pushed.
