### PR TITLE
Lifecycle

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -96,7 +96,7 @@ type ExecAction struct {
 }
 
 type Handler struct {
-	Exec  *ExecAction `json:"exec,omitempty" yaml:"exec,omitempty"`
+	Exec *ExecAction `json:"exec,omitempty" yaml:"exec,omitempty"`
 }
 
 type Lifecycle struct {
@@ -118,7 +118,7 @@ type Container struct {
 	MountSources  bool          `json:"mountSources" yaml:"mountSources"`
 	Command       []string      `json:"command" yaml:"command"`
 	Args          []string      `json:"args" yaml:"args"`
-    Lifecycle     *Lifecycle     `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
+	Lifecycle     *Lifecycle    `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
 }
 
 type ChePlugin struct {

--- a/model/model.go
+++ b/model/model.go
@@ -91,6 +91,19 @@ type ExposedPort struct {
 	ExposedPort int `json:"exposedPort" yaml:"exposedPort"`
 }
 
+type ExecAction struct {
+	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+}
+
+type Handler struct {
+	Exec  ExecAction `json:"exec,omitempty" yaml:"exec,omitempty"`
+}
+
+type Lifecycle struct {
+	PostStart Handler `json:"postStart,omitempty" yaml:"postStart,omitempty"`
+	PreStop   Handler `json:"preStop,omitempty" yaml:"preStop,omitempty"`
+}
+
 type Container struct {
 	Name          string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Image         string        `json:"image,omitempty" yaml:"image,omitempty"`
@@ -105,6 +118,7 @@ type Container struct {
 	MountSources  bool          `json:"mountSources" yaml:"mountSources"`
 	Command       []string      `json:"command" yaml:"command"`
 	Args          []string      `json:"args" yaml:"args"`
+    Lifecycle     Lifecycle     `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
 }
 
 type ChePlugin struct {

--- a/model/model.go
+++ b/model/model.go
@@ -92,7 +92,7 @@ type ExposedPort struct {
 }
 
 type ExecAction struct {
-	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+	Command []string `json:"command" yaml:"command"`
 }
 
 type Handler struct {

--- a/model/model.go
+++ b/model/model.go
@@ -96,12 +96,12 @@ type ExecAction struct {
 }
 
 type Handler struct {
-	Exec  ExecAction `json:"exec,omitempty" yaml:"exec,omitempty"`
+	Exec  *ExecAction `json:"exec,omitempty" yaml:"exec,omitempty"`
 }
 
 type Lifecycle struct {
-	PostStart Handler `json:"postStart,omitempty" yaml:"postStart,omitempty"`
-	PreStop   Handler `json:"preStop,omitempty" yaml:"preStop,omitempty"`
+	PostStart *Handler `json:"postStart,omitempty" yaml:"postStart,omitempty"`
+	PreStop   *Handler `json:"preStop,omitempty" yaml:"preStop,omitempty"`
 }
 
 type Container struct {
@@ -118,7 +118,7 @@ type Container struct {
 	MountSources  bool          `json:"mountSources" yaml:"mountSources"`
 	Command       []string      `json:"command" yaml:"command"`
 	Args          []string      `json:"args" yaml:"args"`
-    Lifecycle     Lifecycle     `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
+    Lifecycle     *Lifecycle     `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
 }
 
 type ChePlugin struct {


### PR DESCRIPTION
### What does this PR do?
Add Lifecycle to the model. This should allow `postStart` and `preStop` actions for plugin containers. More information here: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/ 

In this PR will be introduced only [`ExecAction`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#execaction-v1-core). 
This feature looks useful for some operation that must be called just after start or before stop container. For example some will be used for backup (as `preStop` action) and restore (as `postStart`) project source.

[HTTPGetAction](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#httpgetaction-v1-core) and [TCPSocketAction](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#tcpsocketaction-v1-core) not implement yet.

Docker image for testing:
`docker pull vparfonov/che-plugin-metadata-broker:v3.1.2`