### PR TITLE
Fix plugin broker start when user ID contains colon

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -164,8 +164,8 @@ func Parse() {
 	if len(runtimeIDRaw) == 0 {
 		log.Fatal("Runtime ID required(set it with -runtime-id argument)")
 	}
-	parts := strings.Split(runtimeIDRaw, ":")
-	if len(parts) != 3 {
+	parts := strings.SplitN(runtimeIDRaw, ":", 3)
+	if len(parts) < 3 {
 		log.Fatalf("Expected runtime id to be in format 'workspace:env:ownerId'")
 	}
 	RuntimeID = model.RuntimeID{Workspace: parts[0], Environment: parts[1], OwnerId: parts[2]}


### PR DESCRIPTION
### What does this PR do?
Fix plugin broker start when user ID contains colon.

### What issues does this PR fix or reference?
Quick fix for https://github.com/eclipse/che/issues/15013

### Is it tested? How?
I don't test it on deployed Che with LDAP set up which would lead to `:` in user ID, but the changes are pretty simple and I tested it locally and it seems to work fine
![Screenshot_20200326_144225](https://user-images.githubusercontent.com/5887312/77648228-76e59880-6f70-11ea-9d68-ba2dbaae83d8.png)
