### PR TITLE
Add building dev image to nightly CI

### DIFF
--- a/.cico/cico_build_nightly.sh
+++ b/.cico/cico_build_nightly.sh
@@ -17,7 +17,7 @@ set -e
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 export SCRIPT_DIR
 
-# shellcheck disable=SC1090
+shellcheck disable=SC1090
 . "${SCRIPT_DIR}"/cico_functions.sh
 
 load_jenkins_vars
@@ -28,3 +28,4 @@ build ./build/CI/Dockerfile
 set_nightly_tag
 build_and_push ./build/metadata che-plugin-metadata-broker
 build_and_push ./build/artifacts che-plugin-artifacts-broker
+build_and_push_development_container che-plugin-broker-dev

--- a/.cico/cico_functions.sh
+++ b/.cico/cico_functions.sh
@@ -115,3 +115,13 @@ function build_and_push() {
     echo "CICO: '${TAG}'  version of image pushed to '${REGISTRY}/${ORGANIZATION}/${IMAGE}' repo"
   fi
 }
+
+function build_and_push_development_container() {
+  IMAGE=$1
+  if [ -z "${TAG}" ]; then
+    echo "No tag specified, skipping build of development container"
+    return
+  fi
+  docker build -t "${REGISTRY}/${ORGANIZATION}/${IMAGE}:${TAG}" ./build/dev/
+  docker push "${REGISTRY}/${ORGANIZATION}/${IMAGE}:${TAG}"
+}

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -9,12 +9,17 @@ projects:
       branch: master
     clonePath: src/github.com/eclipse/che-plugin-broker
 components:
-  - id: ms-vscode/go/0.11.0
+  - id: ms-vscode/go/latest
     type: chePlugin
     alias: ms-vscode.go
+    preferences:
+      go.lintTool: 'golangci-lint'
+      go.lintFlags: '--fast'
+      go.useLanguageServer: false
+      go.formatTool: "goimports"
 
   - type: dockerimage
-    image: 'eclipse/che-plugin-broker-dev:latest'
+    image: 'quay.io/eclipse/che-plugin-broker-dev:nightly'
     alias: dev
     mountSources: true
     memoryLimit: 1G
@@ -51,7 +56,7 @@ commands:
           make build-metadata &&
           printf '\033[32mDone.\033[0m'
         component: dev
-  - name: compile "artifacts" plugin broker
+  - name: compile plugin artifacts broker
     actions:
       - workdir: /projects/src/github.com/eclipse/che-plugin-broker
         type: exec
@@ -91,11 +96,23 @@ commands:
     actions:
       - workdir: /projects/src/github.com/eclipse/che-plugin-broker
         type: exec
-        command: './plugin-artifacts-broker --disable-push=true --runtime-id=workspace:developer:eclipse-che --registry-address=http://plugin-registry-local:8080 --metas ./brokers/testdata/config-plugin-ids.json'
+        command: >-
+          make build-artifacts &&
+          ./plugin-artifacts-broker \
+            --disable-push=true \
+            --runtime-id=workspace:developer:eclipse-che \
+            --registry-address=http://plugin-registry-local:8080 \
+            --metas ./brokers/testdata/config-plugin-ids.json
         component: dev
   - name: start plugin metadata broker
     actions:
       - workdir: /projects/src/github.com/eclipse/che-plugin-broker
         type: exec
-        command: './plugin-metadata-broker --disable-push=true --runtime-id=workspace:developer:eclipse-che --registry-address=http://plugin-registry-local:8080 --metas ./brokers/testdata/config-plugin-ids.json'
+        command: >-
+          make build-metadata &&
+          ./plugin-metadata-broker \
+            --disable-push=true \
+            --runtime-id=workspace:developer:eclipse-che \
+            --registry-address=http://plugin-registry-local:8080 \
+            --metas ./brokers/testdata/config-plugin-ids.json
         component: dev

--- a/make-release.sh
+++ b/make-release.sh
@@ -14,9 +14,9 @@ FORCE="false"
 # Wrapper for git commands
 function gitw() {
   if [[ "$1" == "push" ]] && [[ "$TRIGGER_RELEASE" != "true" ]]; then
-    echo -e "    ${RED}'git $@'${NC} (dry run)"
+    echo -e "    ${RED}'git $*'${NC} (dry run)"
   else
-    echo -e "    ${GREEN}git $@${NC}"
+    echo -e "    ${GREEN}git $*${NC}"
     git "$@" 2>&1 | sed 's|^|        |g'
     return "${PIPESTATUS[0]}"
   fi
@@ -101,7 +101,7 @@ cd ./* || exit 1
 
 if [[ "$CREATE_BRANCH" = "true" ]]; then
   echo "Create branch $BRANCH"
-  if git ls-remote --exit-code --heads origin $BRANCH > /dev/null; then
+  if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null; then
     echo "Error: branch $BRANCH already exists in $REPO"
     exit 1
   fi


### PR DESCRIPTION
### What does this PR do?
- Adds building of image quay.io/eclipse/che-plugin-broker-dev:nightly in nightly CI runs to aid dogfooding, as this image is used in the devfile.

- Updates devfile slightly to ease development:
    - Set default preference values for go plugin
    - Use nightly CI-built image
    - Build broker before running 'start' tasksamisevsk

Also cleans up some shellcheck errors

### What issues does this PR fix or reference?
Dogfooding plugin broker

### TODO
- [ ] Create repo in quay.io once PR is approved