### PR TITLE
Make '-race' option configurable for s390x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@ GOENV := CGO_ENABLED=0 GOOS=linux
 GOFLAGS := -a -ldflags '-w -s' -a -installsuffix cgo
 PLUGIN_REGISTRY_URL ?= "https://che-plugin-registry.openshift.io/v3"
 
+ifeq (s390x, $(shell uname -m))
+        RACE ?=
+else
+        RACE ?= -race
+endif
+
 all: ci build
 .PHONY: all
 
@@ -23,7 +29,7 @@ build-metadata:
 
 .PHONY: test
 test:
-	go test -v -race ./...
+	go test -v $(RACE) ./...
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
### What does this PR do?
'-race' flag is not supported on s390x architecture. This PR will remove '-race' option from `go test` command (which gets executed in `make test`).

### What issues does this PR fix or reference?
This PR is part of [this](https://github.com/eclipse/che/issues/16655) initiative.