### PR TITLE
Add command line option for CA bundle directory

### DIFF
--- a/brokers/artifacts/cmd/main.go
+++ b/brokers/artifacts/cmd/main.go
@@ -30,9 +30,7 @@ func main() {
 
 	broker := artifacts.NewBroker(cfg.UseLocalhostInPluginUrls)
 
-	if cfg.SelfSignedCertificateFilePath != "" {
-		common.ConfigureCertPool(cfg.SelfSignedCertificateFilePath)
-	}
+	common.ConfigureCertPool(cfg.SelfSignedCertificateFilePath, cfg.CABundleDirPath)
 
 	if !cfg.DisablePushingToEndpoint {
 		statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)

--- a/brokers/metadata/cmd/main.go
+++ b/brokers/metadata/cmd/main.go
@@ -30,9 +30,7 @@ func main() {
 
 	broker := metadata.NewBroker(cfg.UseLocalhostInPluginUrls)
 
-	if cfg.SelfSignedCertificateFilePath != "" {
-		common.ConfigureCertPool(cfg.SelfSignedCertificateFilePath)
-	}
+	common.ConfigureCertPool(cfg.SelfSignedCertificateFilePath, cfg.CABundleDirPath)
 
 	if !cfg.DisablePushingToEndpoint {
 		statusTun := common.ConnectOrFail(cfg.PushStatusesEndpoint, cfg.Token)

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -67,6 +67,9 @@ var (
 
 	// SelfSignedCertificateFilePath path to certificate file that should be used while connection establishing
 	SelfSignedCertificateFilePath string
+
+	// CABundleDirPath Path to directory with trusted CA certificates
+	CABundleDirPath string
 )
 
 func init() {
@@ -139,6 +142,12 @@ func init() {
 		"",
 		"Path to Certificate that should be used while connection establishing",
 	)
+	flag.StringVar(
+		&CABundleDirPath,
+		"cadir",
+		"",
+		"Path to directory with trusted CA certificates",
+	)
 }
 
 // Parse parses configuration.
@@ -187,6 +196,9 @@ func Print() {
 	log.Printf("    OwnerId: %s", RuntimeID.OwnerId)
 	if SelfSignedCertificateFilePath != "" {
 		log.Printf("  Self signed certificate %s", SelfSignedCertificateFilePath)
+	}
+	if CABundleDirPath != "" {
+		log.Printf("  CA bundle certificates path %s", CABundleDirPath)
 	}
 }
 

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -65,10 +65,12 @@ var (
 	// Used as a default registry if a plugin fully-qualified name does not specify a registry.
 	RegistryAddress string
 
-	// SelfSignedCertificateFilePath path to certificate file that should be used while connection establishing to Che server
+	// SelfSignedCertificateFilePath path to certificate file that should be used while connection establishing to Che server.
+	// Usually it contains Che server self-signed certificate.
 	SelfSignedCertificateFilePath string
 
-	// CABundleDirPath Path to directory with trusted CA certificates
+	// CABundleDirPath Path to directory with trusted CA certificates.
+	// Usually they contain all the trusted CA in the cluster.
 	CABundleDirPath string
 )
 

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -65,7 +65,7 @@ var (
 	// Used as a default registry if a plugin fully-qualified name does not specify a registry.
 	RegistryAddress string
 
-	// SelfSignedCertificateFilePath path to certificate file that should be used while connection establishing
+	// SelfSignedCertificateFilePath path to certificate file that should be used while connection establishing to Che server
 	SelfSignedCertificateFilePath string
 
 	// CABundleDirPath Path to directory with trusted CA certificates

--- a/common/connect.go
+++ b/common/connect.go
@@ -15,13 +15,15 @@ package common
 import (
 	"log"
 	"net/http"
+	"path/filepath"
 
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/eclipse/che-go-jsonrpc"
+	"io/ioutil"
+
+	jsonrpc "github.com/eclipse/che-go-jsonrpc"
 	"github.com/eclipse/che-go-jsonrpc/event"
 	"github.com/eclipse/che-go-jsonrpc/jsonrpcws"
-	"io/ioutil"
 )
 
 type tunnelBroadcaster struct {
@@ -36,22 +38,59 @@ func (tb *tunnelBroadcaster) Accept(e event.E) {
 	}
 }
 
-func ConfigureCertPool(customCertificateFilePath string) {
-	// Get the SystemCertPool, continue with an empty pool on error
+// ConfigureCertPool trusts given certificates
+// CAFilePath is a path to file which contains CA certificates
+// CADirPath is a path to directory with CA certificates files
+func ConfigureCertPool(CAFilePath string, CADirPath string) {
+	if CAFilePath == "" && CADirPath == "" {
+		// Do nothing
+		return
+	}
+
 	rootCAs, _ := x509.SystemCertPool()
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
 	}
 
-	// Read in the cert file
-	certs, err := ioutil.ReadFile(customCertificateFilePath)
-	if err != nil {
-		log.Fatalf("Failed to read custom certificate %q. Error: %v", customCertificateFilePath, err)
+	if CAFilePath != "" {
+		certs, err := ioutil.ReadFile(CAFilePath)
+		if err != nil {
+			log.Fatalf("Failed to read custom certificate %q. Error: %v", CAFilePath, err)
+		}
+
+		// Append our cert to the system pool
+		if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
+			log.Fatalf("Failed to append %q to RootCAs: %v", CAFilePath, err)
+		}
 	}
 
-	// Append our cert to the system pool
-	if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-		log.Fatalf("Failed to append %q to RootCAs: %v", customCertificateFilePath, err)
+	if CADirPath != "" {
+		// Add all certificates from the given directory
+		files, err := ioutil.ReadDir(CADirPath)
+		if err != nil {
+			log.Fatalf("Failed to read certificates from directory %q. Error: %v", CADirPath, err)
+		}
+		// Iterate over all files in the given directory
+		for _, file := range files {
+			if !file.IsDir() {
+				fileExt := filepath.Ext(file.Name())
+				// Look up only for certificate files
+				if fileExt == ".crt" || fileExt == ".pem" {
+					certsFilePath := filepath.Join(CADirPath, file.Name())
+					certs, err := ioutil.ReadFile(certsFilePath)
+					if err != nil {
+						// Log error and continue
+						log.Printf("Failed to read certificate from file %q. Error: %v", certsFilePath, err)
+					} else {
+						// Append certs from the file to the system pool
+						if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
+							// Log error and continue
+							log.Printf("Failed to append %q to RootCAs.", file)
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// Trust the augmented cert pool in our client

--- a/common/connect.go
+++ b/common/connect.go
@@ -74,22 +74,24 @@ func ConfigureCertPool(CAFilePath string, CADirPath string) {
 		}
 		// Iterate over all files in the given directory
 		for _, file := range files {
-			if !file.IsDir() {
-				fileExt := filepath.Ext(file.Name())
-				// Look up only for certificate files
-				if fileExt == ".crt" || fileExt == ".pem" {
-					certsFilePath := filepath.Join(CADirPath, file.Name())
-					certs, err := ioutil.ReadFile(certsFilePath)
-					if err != nil {
-						// Log error and continue
-						log.Printf("Failed to read certificate from file %q. Error: %v", certsFilePath, err)
-					} else {
-						// Append certs from the file to the system pool
-						if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-							// Log error and continue
-							log.Printf("Failed to append %q to RootCAs.", file)
-						}
-					}
+			if file.IsDir() {
+				continue
+			}
+			fileExt := filepath.Ext(file.Name())
+			// Look up only for certificate files
+			if fileExt == ".crt" || fileExt == ".pem" {
+				certsFilePath := filepath.Join(CADirPath, file.Name())
+				certs, err := ioutil.ReadFile(certsFilePath)
+				if err != nil {
+					// Log error and continue
+					log.Printf("Failed to read certificate from file %q. Error: %v", certsFilePath, err)
+					continue
+				}
+				// Append certs from the file to the system pool
+				if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
+					// Log error and continue
+					log.Printf("Failed to append %q to RootCAs.", file)
+					continue
 				}
 			}
 		}

--- a/common/connect.go
+++ b/common/connect.go
@@ -39,8 +39,10 @@ func (tb *tunnelBroadcaster) Accept(e event.E) {
 }
 
 // ConfigureCertPool trusts given certificates
-// CAFilePath is a path to file which contains CA certificates
-// CADirPath is a path to directory with CA certificates files
+// CAFilePath is a path to file which contains CA certificates.
+//   Usually it contains Che server self-signed certificate.
+// CADirPath is a path to directory with CA certificates files.
+//   Usually they contain all the trusted CA in the cluster.
 func ConfigureCertPool(CAFilePath string, CADirPath string) {
 	if CAFilePath == "" && CADirPath == "" {
 		// Do nothing


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds and implements new option `-cadir` which is a path to a dir which contains CA certs bundles. In result plugin brokers trust all the certificates in all the files in the provided directory if any.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17552
