### PR TITLE
Update devfile.yaml to include latest go plugin

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -9,7 +9,7 @@ projects:
       branch: master
     clonePath: src/github.com/eclipse/che-plugin-broker
 components:
-  - id: ms-vscode/go/0.11.0
+  - id: golang/go/latest
     type: chePlugin
     alias: ms-vscode.go
 


### PR DESCRIPTION
### What does this PR do?
Updates the go plugin used in the devfile to use the `latest` version and changes the ID to reflect https://github.com/eclipse-che/che-plugin-registry/pull/509

### What issues does this PR fix or reference?
Factory URLs for this repo no longer work.
